### PR TITLE
Ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+beringei/if/gen-cpp2/
+build/


### PR DESCRIPTION
Summary:
Add a .gitignore file to ignore build artifacts.

Test Plan:
Built Beringei. Observed no untracked files in `git status`.