### PR TITLE
[beringei] Automate the build/generation of thrift files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,17 @@ include(CheckFunctionExists)
 include(BeringeiCompilerOptions)
 
 set(BERINGEI_HOME ${CMAKE_CURRENT_SOURCE_DIR})
+
+message("Building Required Thrift Files")
+execute_process(
+  COMMAND bash "-e" "build_thrift.sh"
+  WORKING_DIRECTORY ${BERINGEI_HOME}/beringei/if
+  RESULT_VARIABLE thrift_build_result)
+
+if(NOT "${thrift_build_result}" STREQUAL "0")
+    message(FATAL_ERROR "Could not build thrfft file.")
+endif()
+
 set(TP_PROJECTS_DIR "beringei/third-party")
 # So that qualified includes work. E.g. #include "beringei/client/$x.h"
 include_directories(${BERINGEI_HOME})

--- a/README.md
+++ b/README.md
@@ -48,14 +48,6 @@ the install scripts and directions to work with other linux distros.
 
 Run `sudo ./setup_ubuntu.sh`.
 
-Generate the the thrift source:
-```
-pushd beringei/if
-for THRIFT_FILE in $(ls *.thrift); do
-  PYTHONPATH=/tmp/fbthrift-2016.11.07.00/thrift/.python-local/lib/python  python2 -mthrift_compiler.main --gen cpp2 $THRIFT_FILE -I../..
-done
-popd
-```
 Actually build beringei
 `mkdir build && cd build && cmake .. && make`
 

--- a/beringei/if/CMakeLists.txt
+++ b/beringei/if/CMakeLists.txt
@@ -11,6 +11,11 @@ include_directories(gen-cpp2)
 # Uplevel the path to this so lower things can use it.
 set(BERINGEI_THRIFT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2 PARENT)
 
+add_custom_target(
+  beringei_gen_thrift_headers
+  COMMAND bash "-e" "build_thrift.sh"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_library(
     beringei_thrift STATIC
     gen-cpp2/BeringeiService.h
@@ -40,12 +45,14 @@ add_library(
     gen-cpp2/beringei_grafana_types.tcc
 )
 
-target_link_libraries(
-    beringei_thrift
-    ${FBTHRIFT_LIBRARIES}
+add_dependencies(
+  beringei_thrift
+
+  beringei_gen_thrift_headers
 )
 
-add_custom_command(TARGET beringei_thrift
-  PRE_BUILD
-  COMMAND bash "-e" "build_thrift.sh"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(
+    beringei_thrift
+
+    ${FBTHRIFT_LIBRARIES}
+)

--- a/beringei/if/CMakeLists.txt
+++ b/beringei/if/CMakeLists.txt
@@ -44,3 +44,8 @@ target_link_libraries(
     beringei_thrift
     ${FBTHRIFT_LIBRARIES}
 )
+
+add_custom_command(TARGET beringei_thrift
+  PRE_BUILD
+  COMMAND bash "-e" "build_thrift.sh"
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/beringei/if/build_thrift.sh
+++ b/beringei/if/build_thrift.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# fail script on any error
+set -e
+
+# build every thrift file
+for THRIFT_FILE in $(ls *.thrift); do
+    echo "Building file: " $THRIFT_FILE
+    PYTHONPATH=/tmp/fbthrift-2016.11.07.00/thrift/.python-local/lib/python  python2 -mthrift_compiler.main --gen cpp2 $THRIFT_FILE -I../..
+done

--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -18,6 +18,7 @@ apt install --yes \
     automake \
     binutils-dev \
     bison \
+    clang-format-3.9 \
     cmake \
     flex \
     g++ \


### PR DESCRIPTION
Summary: 
Currently we expect the user/developer to build/generate thrift files before running 'cmake ..'. This also means that users/developers need to remember to build thrift files on every change. This diff automates the process.

execute_process() is run on 'cmake ..'
add_custom_command() is run on 'make'

The one disadvantage of this is that 'make' will now always rebuild every target that depends on these thrift files.

Test Plan:

1) Test 'cmake ..' with no build errors
OUTPUT: 
-- FOLLY: /usr/local/facebook/include
-- WANGLE: /usr/local/facebook/include
-- PROXYGEN: /usr/local/facebook/include
Building Required Thrift Files
Building file:  beringei_data.thrift
Building file:  beringei_grafana.thrift
Building file:  beringei.thrift
-- Configuring done
-- Generating done

2) Test 'cmake.. ' with build error

OUTPUT:
-- FOLLY: /usr/local/facebook/include
-- WANGLE: /usr/local/facebook/include
-- PROXYGEN: /usr/local/facebook/include
Building Required Thrift Files
Building file:  beringei_data.thrift
[ERROR:beringei_data.thrift:13] (last token was 'sruct')
syntax error
[FAILURE:beringei_data.thrift:13] Parser error during include pass.
CMake Error at CMakeLists.txt:56 (message):
  Could not build thrfft file.

3) Test 'make' with no build errors -> Success

4) Test 'make' with build errors

OUTPUT:
[ 15%] Built target beringei_test_util
[ 16%] Building CXX object beringei/if/CMakeFiles/beringei_thrift.dir/gen-cpp2/BeringeiService_processmap_compact.cpp.o
[ 17%] Building CXX object beringei/if/CMakeFiles/beringei_thrift.dir/gen-cpp2/beringei_constants.cpp.o
[ 18%] Building CXX object beringei/if/CMakeFiles/beringei_thrift.dir/gen-cpp2/beringei_data_types.cpp.o
[ 19%] Building CXX object beringei/if/CMakeFiles/beringei_thrift.dir/gen-cpp2/beringei_data_constants.cpp.o
[ 20%] Building CXX object beringei/if/CMakeFiles/beringei_thrift.dir/gen-cpp2/beringei_types.cpp.o
[ 21%] Building CXX object beringei/if/CMakeFiles/beringei_thrift.dir/gen-cpp2/beringei_grafana_constants.cpp.o
[ 22%] Building CXX object beringei/if/CMakeFiles/beringei_thrift.dir/gen-cpp2/beringei_grafana_types.cpp.o
[ 23%] Linking CXX static library libberingei_thrift.a
Building file:  beringei_data.thrift
Building file:  beringei_grafana.thrift
Building file:  beringei.thrift
[ERROR:beringei.thrift:15] (last token was 'ervice')
syntax error
[FAILURE:beringei.thrift:15] Parser error during include pass.
beringei/if/CMakeFiles/beringei_thrift.dir/build.make:328: recipe for target 'beringei/if/libberingei_thrift.a' failed
make[2]: *** [beringei/if/libberingei_thrift.a] Error 1
CMakeFiles/Makefile2:173: recipe for target 'beringei/if/CMakeFiles/beringei_thrift.dir/all' failed
make[1]: *** [beringei/if/CMakeFiles/beringei_thrift.dir/all] Error 2
Makefile:138: recipe for target 'all' failed
make: *** [all] Error 2