### PR TITLE
Add Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 beringei/if/gen-cpp2/
 build/
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,24 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  # the base box is ubuntu 16.10
+  config.vm.box = "bento/ubuntu-16.10"
+
+  # check update
+  config.vm.box_check_update = true
+
+  # forward guest 80 to host 8080
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  config.vm.provider "virtualbox" do |vb|
+     # Don't show the GUI unless you have some bug
+     vb.gui = false
+     # Customize the amount of memory on the VM:
+     vb.memory = "1024"
+  end
+
+  config.vm.provision "shell", path: "setup_ubuntu.sh"
+
+end


### PR DESCRIPTION
This PR add `Vagrantfile` for using [vagrant](https://www.vagrantup.com/). It's more friendly for development than docker, you just need `vagrant up` and it will mount the folder into `/vagrant` in the guest vm. I've test it on some OS, maybe someone with a Mac can help test if works for Mac OS.

- when run `vagrant up` for the first time, it will run `setup_ubuntu.sh`
- tested host
  - Fedora 25
  - Ubuntu 16.04 LTS
  - Windows 10

And I don't know if it's possible to have a `hack` folder like [k8s did](https://github.com/kubernetes/kubernetes/tree/master/hack), to put all the environment setup, test script (in the readme), format check scripts together, though there is one `setup_ubuntu.sh` but there could be more in the future.

`````
beringei
  build
  beringei
  hack 
   setup_ubuntu.sh
   gen_config.sh
   start_beringei.sh
   insert_random.sh
   read.sh
   check_format.sh
````