### PR TITLE
Fix build break - Add ShardData.* to Makefile

### DIFF
--- a/beringei/lib/CMakeLists.txt
+++ b/beringei/lib/CMakeLists.txt
@@ -53,6 +53,8 @@ add_library(
     NetworkUtils.h
     PersistentKeyList.cpp
     PersistentKeyList.h
+    ShardData.cpp
+    ShardData.h
     SimpleMemoryUsageGuard.cpp
     SimpleMemoryUsageGuard.h
     TimeSeries.cpp


### PR DESCRIPTION
Summary: Fix beringei build break

Test Plan: CircleCI build passes. https://circleci.com/gh/kiranisaac/beringei-1/1