### PR TITLE
Add cleaner thread to beringei

### DIFF
--- a/beringei/service/BeringeiServiceHandler.h
+++ b/beringei/service/BeringeiServiceHandler.h
@@ -57,6 +57,7 @@ class BeringeiServiceHandler : virtual public BeringeiServiceSvIf {
       int32_t limit) override;
 
   void purgeThread();
+  void cleanThread();
 
   // Purges time series that have no data in the active bucket and not
   // in any of the `numBuckets` older buckets.
@@ -78,6 +79,7 @@ class BeringeiServiceHandler : virtual public BeringeiServiceSvIf {
   const int32_t port_;
 
   folly::FunctionScheduler purgeThread_;
+  folly::FunctionScheduler cleanThread_;
   folly::FunctionScheduler bucketFinalizerThread_;
   folly::FunctionScheduler refreshShardConfigThread_;
 };

--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -54,7 +54,7 @@ ready_destdir() {
 }
 
 mkdir -pv /usr/local/facebook-${FB_VERSION}
-ln -s /usr/local/facebook-${FB_VERSION} /usr/local/facebook
+ln -sf /usr/local/facebook-${FB_VERSION} /usr/local/facebook
 
 export LDFLAGS="-L/usr/local/facebook/lib -Wl,-rpath=/usr/local/facebook/lib"
 export CPPFLAGS="-I/usr/local/facebook/include"


### PR DESCRIPTION
Looks like we missed porting the cleaner thread to beringei (which periodically goes through and compacts the keylist and deletes old block files). This should make the service more stable/efficient over time.

Tested by running the service for > 24 hours while constantly pushing data into it:
```
  ./beringei/service/beringei_main \
    -beringei_configuration_path /tmp/beringei.json \
    -create_directories \
    -sleep_between_bucket_finalization_secs 60 \
    -allowed_timestamp_behind 300 \
    -bucket_size 600 \
    -buckets $((86400/600)) \
    -logtostderr \
    -v=2
```
In another terminal:
```
  while [[ 1 ]]; do
    ./beringei/tools/beringei_put \
        -beringei_configuration_path /tmp/beringei.json \
        testkey ${RANDOM} \
        -logtostderr -v 3
    sleep 30
done
```