### PR TITLE
[beringei] Fix the build

### DIFF
--- a/beringei/client/CMakeLists.txt
+++ b/beringei/client/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
     beringei_core
     beringei_thrift
     ${FOLLY_LIBRARIES}
+    ${WANGLE_LIBRARIES}
 )
 
 add_subdirectory(tests)

--- a/beringei/client/tests/CMakeLists.txt
+++ b/beringei/client/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
     BeringeiClientTest.cpp
     BeringeiGetResultTest.cpp
     RequestBatchingQueueTest.cpp
+    TestMain.cpp
 )
 target_link_libraries(
     beringei_client_test_bin

--- a/beringei/client/tests/TestMain.cpp
+++ b/beringei/client/tests/TestMain.cpp
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2017, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/beringei/if/CMakeLists.txt
+++ b/beringei/if/CMakeLists.txt
@@ -18,31 +18,36 @@ add_custom_target(
 
 add_library(
     beringei_thrift STATIC
-    gen-cpp2/BeringeiService.h
-    gen-cpp2/BeringeiService_custom_protocol.h
-    gen-cpp2/beringei_constants.h
-    gen-cpp2/beringei_data_constants.h
-    gen-cpp2/beringei_data_types.h
-    gen-cpp2/beringei_data_types_custom_protocol.h
-    gen-cpp2/beringei_types.h
-    gen-cpp2/beringei_types_custom_protocol.h
     gen-cpp2/BeringeiService.cpp
+    gen-cpp2/BeringeiService.h
+    gen-cpp2/BeringeiService.tcc
     gen-cpp2/BeringeiService_client.cpp
+    gen-cpp2/BeringeiService_custom_protocol.h
     gen-cpp2/BeringeiService_processmap_binary.cpp
     gen-cpp2/BeringeiService_processmap_compact.cpp
     gen-cpp2/beringei_constants.cpp
+    gen-cpp2/beringei_constants.h
     gen-cpp2/beringei_data_constants.cpp
+    gen-cpp2/beringei_data_constants.h
+    gen-cpp2/beringei_data_constants.h
+    gen-cpp2/beringei_data_data.cpp
+    gen-cpp2/beringei_data_data.cpp
     gen-cpp2/beringei_data_types.cpp
-    gen-cpp2/beringei_types.cpp
-    gen-cpp2/BeringeiService.tcc
+    gen-cpp2/beringei_data_types.h
     gen-cpp2/beringei_data_types.tcc
-    gen-cpp2/beringei_types.tcc
+    gen-cpp2/beringei_data_types_custom_protocol.h
     gen-cpp2/beringei_grafana_constants.cpp
     gen-cpp2/beringei_grafana_constants.h
+    gen-cpp2/beringei_grafana_data.cpp
+    gen-cpp2/beringei_grafana_data.h
     gen-cpp2/beringei_grafana_types.cpp
-    gen-cpp2/beringei_grafana_types_custom_protocol.h
     gen-cpp2/beringei_grafana_types.h
     gen-cpp2/beringei_grafana_types.tcc
+    gen-cpp2/beringei_grafana_types_custom_protocol.h
+    gen-cpp2/beringei_types.cpp
+    gen-cpp2/beringei_types.h
+    gen-cpp2/beringei_types.tcc
+    gen-cpp2/beringei_types_custom_protocol.h
 )
 
 add_dependencies(

--- a/beringei/lib/tests/CMakeLists.txt
+++ b/beringei/lib/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
     TestKeyList.cpp
     TestDataLoader.h
     TestDataLoader.cpp
+    TestMain.cpp
 )
 
 add_executable(

--- a/beringei/lib/tests/TestMain.cpp
+++ b/beringei/lib/tests/TestMain.cpp
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2017, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/beringei/plugins/tests/CMakeLists.txt
+++ b/beringei/plugins/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(
     BeringeiConfigurationAdapterTest.cpp
     BeringeiConfigurationTest.cpp
     BeringeiConfigurationValidationTest.cpp
+    TestMain.cpp
 )
 
 target_link_libraries(

--- a/beringei/plugins/tests/TestMain.cpp
+++ b/beringei/plugins/tests/TestMain.cpp
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2017, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/beringei/service/tests/CMakeLists.txt
+++ b/beringei/service/tests/CMakeLists.txt
@@ -5,7 +5,12 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-add_executable(beringei_service_test_bin BeringeiServiceHandlerTest.cpp)
+add_executable(
+    beringei_service_test_bin
+
+    BeringeiServiceHandlerTest.cpp
+    TestMain.cpp
+)
 
 target_link_libraries(
     beringei_service_test_bin

--- a/beringei/service/tests/TestMain.cpp
+++ b/beringei/service/tests/TestMain.cpp
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2017, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+#include <gtest/gtest.h>
+
+#include <folly/init/Init.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}

--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 set -e
 
-FB_VERSION="2016.11.07.00"
+FB_VERSION="2017.04.24.00"
 ZSTD_VERSION="1.1.1"
-
-# proxygen does not tag their build
-PROXYGEN_COMMIT_HASH="8e76dac9c30ca82aebd56b8d7c61b6dbdd7e1316"
 
 echo "This script configures ubuntu with everything needed to run beringei."
 echo "It requires that you run it as root. sudo works great for that."
@@ -54,7 +51,7 @@ ready_destdir() {
 }
 
 mkdir -pv /usr/local/facebook-${FB_VERSION}
-ln -sf /usr/local/facebook-${FB_VERSION} /usr/local/facebook
+ln -sfT /usr/local/facebook-${FB_VERSION} /usr/local/facebook
 
 export LDFLAGS="-L/usr/local/facebook/lib -Wl,-rpath=/usr/local/facebook/lib"
 export CPPFLAGS="-I/usr/local/facebook/include"
@@ -64,7 +61,7 @@ cd /tmp
 wget -O /tmp/folly-${FB_VERSION}.tar.gz https://github.com/facebook/folly/archive/v${FB_VERSION}.tar.gz
 wget -O /tmp/wangle-${FB_VERSION}.tar.gz https://github.com/facebook/wangle/archive/v${FB_VERSION}.tar.gz
 wget -O /tmp/fbthrift-${FB_VERSION}.tar.gz https://github.com/facebook/fbthrift/archive/v${FB_VERSION}.tar.gz
-wget -O /tmp/proxygen-${FB_VERSION}.tar.gz https://github.com/facebook/proxygen/archive/${PROXYGEN_COMMIT_HASH}.tar.gz
+wget -O /tmp/proxygen-${FB_VERSION}.tar.gz https://github.com/facebook/proxygen/archive/v${FB_VERSION}.tar.gz
 wget -O /tmp/mstch-master.tar.gz https://github.com/no1msd/mstch/archive/master.tar.gz
 wget -O /tmp/zstd-${ZSTD_VERSION}.tar.gz https://github.com/facebook/zstd/archive/v${ZSTD_VERSION}.tar.gz
 
@@ -72,8 +69,6 @@ tar xzvf folly-${FB_VERSION}.tar.gz
 tar xzvf wangle-${FB_VERSION}.tar.gz
 tar xzvf fbthrift-${FB_VERSION}.tar.gz
 tar xzvf proxygen-${FB_VERSION}.tar.gz
-# temporary workaround till proxygen starts to tag their builds
-mv /tmp/proxygen-${PROXYGEN_COMMIT_HASH} /tmp/proxygen-${FB_VERSION}
 tar xzvf mstch-master.tar.gz
 tar xzvf zstd-${ZSTD_VERSION}.tar.gz
 


### PR DESCRIPTION
Summary:
7138b7d exposed the fact that our dependencies are all very old.

We still need to come up with a beter solution than manually updating
when things break, but for now, this gets things working again by
bumping the version numbers.

Updating the dependencies also broke two things that required fixing:
- fbthrift now generates extra files that need compiling
- folly::Singleton doesn't like being used before folly::init()

Test Plan:
- `make test` passes
- `beringei_main` runs without crashing