### PR TITLE
[beringei] Improve CMake dependency tree

### DIFF
--- a/beringei/client/tests/CMakeLists.txt
+++ b/beringei/client/tests/CMakeLists.txt
@@ -14,6 +14,8 @@ add_executable(
     RequestBatchingQueueTest.cpp
     TestMain.cpp
 )
+add_dependencies(beringei_client_test_bin gtest_tp)
+
 target_link_libraries(
     beringei_client_test_bin
 

--- a/beringei/if/CMakeLists.txt
+++ b/beringei/if/CMakeLists.txt
@@ -11,53 +11,67 @@ include_directories(gen-cpp2)
 # Uplevel the path to this so lower things can use it.
 set(BERINGEI_THRIFT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2 PARENT)
 
-add_custom_target(
-  beringei_gen_thrift_headers
-  COMMAND bash "-e" "build_thrift.sh"
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+set(
+    THRIFT_FILES
+    beringei_data.thrift
+    beringei_grafana.thrift
+    beringei.thrift
+)
+
+set(
+    THRIFT_GEN
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/BeringeiService.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/BeringeiService.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/BeringeiService.tcc
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/BeringeiService_client.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/BeringeiService_custom_protocol.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/BeringeiService_processmap_binary.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/BeringeiService_processmap_compact.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_constants.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_constants.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_data.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_data.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_data_constants.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_data_constants.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_data_data.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_data_data.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_data_types.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_data_types.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_data_types.tcc
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_data_types_custom_protocol.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_grafana_constants.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_grafana_constants.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_grafana_data.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_grafana_data.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_grafana_types.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_grafana_types.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_grafana_types.tcc
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_grafana_types_custom_protocol.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_types.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_types.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_types.tcc
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_types_custom_protocol.h
+)
+
+add_custom_command(
+  OUTPUT ${THRIFT_GEN}
+  COMMAND bash "build_thrift.sh" ${THRIFT_FILES}
+  MAIN_DEPENDENCY build_thrift.sh
+  DEPENDS ${THRIFT_FILES}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+set_source_files_properties(
+    ${THRIFT_GEN}
+    PROPERTIES GENERATED TRUE
+)
 
 add_library(
     beringei_thrift STATIC
-    gen-cpp2/BeringeiService.cpp
-    gen-cpp2/BeringeiService.h
-    gen-cpp2/BeringeiService.tcc
-    gen-cpp2/BeringeiService_client.cpp
-    gen-cpp2/BeringeiService_custom_protocol.h
-    gen-cpp2/BeringeiService_processmap_binary.cpp
-    gen-cpp2/BeringeiService_processmap_compact.cpp
-    gen-cpp2/beringei_constants.cpp
-    gen-cpp2/beringei_constants.h
-    gen-cpp2/beringei_data_constants.cpp
-    gen-cpp2/beringei_data_constants.h
-    gen-cpp2/beringei_data_constants.h
-    gen-cpp2/beringei_data_data.cpp
-    gen-cpp2/beringei_data_data.cpp
-    gen-cpp2/beringei_data_types.cpp
-    gen-cpp2/beringei_data_types.h
-    gen-cpp2/beringei_data_types.tcc
-    gen-cpp2/beringei_data_types_custom_protocol.h
-    gen-cpp2/beringei_grafana_constants.cpp
-    gen-cpp2/beringei_grafana_constants.h
-    gen-cpp2/beringei_grafana_data.cpp
-    gen-cpp2/beringei_grafana_data.h
-    gen-cpp2/beringei_grafana_types.cpp
-    gen-cpp2/beringei_grafana_types.h
-    gen-cpp2/beringei_grafana_types.tcc
-    gen-cpp2/beringei_grafana_types_custom_protocol.h
-    gen-cpp2/beringei_types.cpp
-    gen-cpp2/beringei_types.h
-    gen-cpp2/beringei_types.tcc
-    gen-cpp2/beringei_types_custom_protocol.h
-)
-
-add_dependencies(
-  beringei_thrift
-
-  beringei_gen_thrift_headers
+    ${THRIFT_GEN}
 )
 
 target_link_libraries(
     beringei_thrift
-
     ${FBTHRIFT_LIBRARIES}
 )

--- a/beringei/if/build_thrift.sh
+++ b/beringei/if/build_thrift.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-# Fail script on any error
+# Fail script on any error.
 set -e
 
-# Build thrift files
+# Build thrift files.
 for THRIFT_FILE in "$@"; do
     echo "Building file: " $THRIFT_FILE
     python2 -mthrift_compiler.main --gen cpp2 "$THRIFT_FILE" -I../..

--- a/beringei/if/build_thrift.sh
+++ b/beringei/if/build_thrift.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# fail script on any error
+# Fail script on any error
 set -e
 
-# build every thrift file
-for THRIFT_FILE in $(ls *.thrift); do
+# Build thrift files
+for THRIFT_FILE in "$@"; do
     echo "Building file: " $THRIFT_FILE
-    PYTHONPATH=/tmp/fbthrift-2016.11.07.00/thrift/.python-local/lib/python  python2 -mthrift_compiler.main --gen cpp2 $THRIFT_FILE -I../..
+    python2 -mthrift_compiler.main --gen cpp2 "$THRIFT_FILE" -I../..
 done

--- a/beringei/lib/tests/CMakeLists.txt
+++ b/beringei/lib/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(
     TestDataLoader.cpp
     TestMain.cpp
 )
+add_dependencies(beringei_test_util gtest_tp)
 
 add_executable(
     beringei_core_test_bin

--- a/beringei/plugins/tests/CMakeLists.txt
+++ b/beringei/plugins/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(
     BeringeiConfigurationValidationTest.cpp
     TestMain.cpp
 )
+add_dependencies(beringei_plugin_test_bin gtest_tp)
 
 target_link_libraries(
     beringei_plugin_test_bin

--- a/beringei/service/tests/CMakeLists.txt
+++ b/beringei/service/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(
     BeringeiServiceHandlerTest.cpp
     TestMain.cpp
 )
+add_dependencies(beringei_service_test_bin gtest_tp)
 
 target_link_libraries(
     beringei_service_test_bin

--- a/beringei/third-party/gtest/CMakeLists.txt
+++ b/beringei/third-party/gtest/CMakeLists.txt
@@ -14,6 +14,8 @@ set(GTEST_DISABLE_PTHREADS OFF)
 
 find_package(Threads REQUIRED)
 
+set(GTEST_DIR "${CMAKE_BINARY_DIR}/beringei/third-party/gtest/src")
+
 externalproject_add(
     gtest_tp
     GIT_REPOSITORY https://github.com/google/googletest.git
@@ -24,6 +26,7 @@ externalproject_add(
         -DBUILD_GTEST=ON
         -DBUILD_GMOCK=ON
     PREFIX "${CMAKE_CURRENT_BINARY_DIR}"
+    BUILD_BYPRODUCTS "${GTEST_DIR}/gtest_tp-build/googlemock/libgmock_main.a"
     # Disable install step
     INSTALL_COMMAND ""
     )


### PR DESCRIPTION
Summary:
- Require gtest headers to be downloaded before building unit tests
- Turn thrift generation into a proper build target

Test Plan:
- Clean clean build with -j10 now succeeds instead of failing
- Repeated `make` now does not recompile everything
- Touching any .thrift file or build_thrift.sh still causes a rebuild
- `make clean` now deletes thrift-generated files
- Build now works with ninja:
  `mkdir build && cd build && cmake -GNinja ..  && ninja`