### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Docker
+**/.dockerignore
+**/*Dockerfile
+
+# Circle-ci
+**/*circle.yml
+
+# Vagrant
+**/*Vagrantfile
+**/.vagrant/
+
+# Vim swap files
+**/.*.sw[po]
+
+
+**/*CONTRIBUTING.md
+**/*PATENTS
+
+# Beringei builds
+build/
+beringei/if/gen-cpp2/


### PR DESCRIPTION
This is a very simple PR. It just adds a .dockerignore file. This helps with docker caching, since we add the whole directory while building the docker image, ignoring those files does not trigger new steps. As a result cached steps will not be used only when the code itself changes.