### PR TITLE
Update dependency versions

### DIFF
--- a/fbthrift.patch
+++ b/fbthrift.patch
@@ -1,0 +1,13 @@
+diff --git a/thrift/lib/thrift/Makefile.am b/thrift/lib/thrift/Makefile.am
+index e471129..72bf8c3 100644
+--- a/thrift/lib/thrift/Makefile.am
++++ b/thrift/lib/thrift/Makefile.am
+@@ -39,7 +39,7 @@ BUILT_SOURCES = \
+ 	gen-cpp2/frozen_data.cpp \
+ 	gen-cpp2/frozen_types.cpp
+ 
+-gen-cpp2/frozen_data.h gen-cpp2/frozen_types.h: frozen.thrift
++gen-cpp2/frozen_data.h gen-cpp2/frozen_types.h: frozen.thrift gen-cpp/frozen_types.h gen-cpp/reflection_types.h
+ 	PYTHONPATH=$(PY_LOCAL_PATH) $(PYTHON) -mthrift_compiler.main --gen cpp2 $<
+ 
+ gen-cpp2/frozen_constants.cpp: gen-cpp2/frozen_types.h

--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -5,6 +5,8 @@ FB_VERSION="2017.07.31.00"
 WANGLE_COMMIT="e79e15163bc6cb1ee343b883ce769b8e3cbd1e96"
 ZSTD_VERSION="1.3.0"
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 echo "This script configures ubuntu with everything needed to run beringei."
 echo "It requires that you run it as root. sudo works great for that."
 
@@ -98,6 +100,7 @@ make install
 popd
 
 pushd fbthrift-${FB_VERSION}/thrift
+patch -p2 -i "${SCRIPT_DIR}/fbthrift.patch"
 autoreconf -ivf
 ./configure --prefix=/usr/local/facebook-${FB_VERSION}
 make install

--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
 
-FB_VERSION="2017.05.22.00"
-ZSTD_VERSION="1.1.1"
+FB_VERSION="2017.07.31.00"
+WANGLE_COMMIT="e79e15163bc6cb1ee343b883ce769b8e3cbd1e96"
+ZSTD_VERSION="1.3.0"
 
 echo "This script configures ubuntu with everything needed to run beringei."
 echo "It requires that you run it as root. sudo works great for that."
@@ -59,14 +60,14 @@ export CPPFLAGS="-I/usr/local/facebook/include"
 cd /tmp
 
 wget -O /tmp/folly-${FB_VERSION}.tar.gz https://github.com/facebook/folly/archive/v${FB_VERSION}.tar.gz
-wget -O /tmp/wangle-${FB_VERSION}.tar.gz https://github.com/facebook/wangle/archive/v${FB_VERSION}.tar.gz
+wget -O /tmp/wangle-${WANGLE_COMMIT}.tar.gz https://github.com/facebook/wangle/archive/${WANGLE_COMMIT}.tar.gz
 wget -O /tmp/fbthrift-${FB_VERSION}.tar.gz https://github.com/facebook/fbthrift/archive/v${FB_VERSION}.tar.gz
 wget -O /tmp/proxygen-${FB_VERSION}.tar.gz https://github.com/facebook/proxygen/archive/v${FB_VERSION}.tar.gz
 wget -O /tmp/mstch-master.tar.gz https://github.com/no1msd/mstch/archive/master.tar.gz
 wget -O /tmp/zstd-${ZSTD_VERSION}.tar.gz https://github.com/facebook/zstd/archive/v${ZSTD_VERSION}.tar.gz
 
 tar xzvf folly-${FB_VERSION}.tar.gz
-tar xzvf wangle-${FB_VERSION}.tar.gz
+tar xzvf wangle-${WANGLE_COMMIT}.tar.gz
 tar xzvf fbthrift-${FB_VERSION}.tar.gz
 tar xzvf proxygen-${FB_VERSION}.tar.gz
 tar xzvf mstch-master.tar.gz
@@ -88,7 +89,7 @@ autoreconf -ivf
 make install
 popd
 
-pushd wangle-${FB_VERSION}/wangle
+pushd wangle-${WANGLE_COMMIT}/wangle
 cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local/facebook-${FB_VERSION} -DBUILD_SHARED_LIBS:BOOL=ON .
 make
 # Wangle tests are broken. Disabling ctest.


### PR DESCRIPTION
Summary:
Pull in the latest changes from various dependencies.

- Update FB dependencies to a newer date
- Use a commit hash for wangle, since its version tagging seems to have
  failed this week
- Update to the latest zstd version

Test Plan:
- It builds
- Tests pass