### PR TITLE
Add type-ahead query handler to beringei query service T22220874

### DIFF
--- a/beringei/if/CMakeLists.txt
+++ b/beringei/if/CMakeLists.txt
@@ -15,6 +15,7 @@ set(
     THRIFT_FILES
     beringei_data.thrift
     beringei_grafana.thrift
+    beringei_query.thrift
     beringei.thrift
 )
 
@@ -47,6 +48,14 @@ set(
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_grafana_types.h
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_grafana_types.tcc
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_grafana_types_custom_protocol.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_query_constants.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_query_constants.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_query_data.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_query_data.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_query_types.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_query_types.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_query_types.tcc
+    ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_query_types_custom_protocol.h
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_types.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_types.h
     ${CMAKE_CURRENT_SOURCE_DIR}/gen-cpp2/beringei_types.tcc

--- a/beringei/if/beringei.thrift
+++ b/beringei/if/beringei.thrift
@@ -30,7 +30,7 @@ service BeringeiService {
    * blacklisted items were filtered out or that's the last batch.
    */
   beringei_data.GetShardDataBucketResult getShardDataBucket(
-      1: i64 begin, 2: i64 end, 3: i64 shardId, 4: i32 offset, 5: i32 limit),
+      1: i64 begin1, 2: i64 end1, 3: i64 shardId, 4: i32 offset, 5: i32 limit),
 
   /**
    * Gets the last update times for time series.

--- a/beringei/if/beringei_grafana.thrift
+++ b/beringei/if/beringei_grafana.thrift
@@ -44,30 +44,24 @@ namespace py facebook.gorilla.beringei_grafana
   and folly::toJson().
 
 */
-
-struct QueryRawRange {
-  1: string from,
-  2: string to,
+struct KeyData {
+  1: i64 keyId,
+  2: string key,
+  10: optional string displayName,
+  11: optional string linkName,
+  20: optional string node,
+  21: optional string nodeName,
+  30: optional string siteName,
 }
 
-struct QueryRange {
-  1: string from,
-  2: string to,
-  3: QueryRawRange raw,
-}
-
-struct QueryTarget {
-  1: string target,
-  2: string refId,
+struct Query {
+  1: string type,
+  2: list<i64> key_ids,
+  3: list<KeyData> data,
+  4: i32 min_ago,
+  5: string agg_type,
 }
 
 struct QueryRequest {
-  1: i32 panelId,
-  2: QueryRange range,
-  3: QueryRawRange rangeRaw,
-  4: string interval,
-  5: i32 intervalMs,
-  6: list<QueryTarget> targets,
-  7: string format,
-  8: i32 maxDataPoints,
+  1: list<Query> queries,
 }

--- a/beringei/if/beringei_grafana.thrift
+++ b/beringei/if/beringei_grafana.thrift
@@ -1,12 +1,3 @@
-/**
- * Copyright (c) 2016-present, Facebook, Inc.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- */
-
 namespace cpp2 facebook.gorilla
 namespace py facebook.gorilla.beringei_grafana
 
@@ -44,24 +35,30 @@ namespace py facebook.gorilla.beringei_grafana
   and folly::toJson().
 
 */
-struct KeyData {
-  1: i64 keyId,
-  2: string key,
-  10: optional string displayName,
-  11: optional string linkName,
-  20: optional string node,
-  21: optional string nodeName,
-  30: optional string siteName,
+
+struct QueryRawRange {
+  1: string from,
+  2: string to,
 }
 
-struct Query {
-  1: string type,
-  2: list<i64> key_ids,
-  3: list<KeyData> data,
-  4: i32 min_ago,
-  5: string agg_type,
+struct QueryRange {
+  1: string from,
+  2: string to,
+  3: QueryRawRange raw,
+}
+
+struct QueryTarget {
+  1: string target,
+  2: string refId,
 }
 
 struct QueryRequest {
-  1: list<Query> queries,
+  1: i32 panelId,
+  2: QueryRange range,
+  3: QueryRawRange rangeRaw,
+  4: string interval,
+  5: i32 intervalMs,
+  6: list<QueryTarget> targets,
+  7: string format,
+  8: i32 maxDataPoints,
 }

--- a/beringei/if/beringei_query.thrift
+++ b/beringei/if/beringei_query.thrift
@@ -14,7 +14,7 @@ struct KeyData {
   1: i64 keyId,
   2: string key,
 
-  10: optional string displayName,
+  10: string displayName,
   11: optional string linkName,
   // extra title for link
   12: optional string linkTitleAppend,

--- a/beringei/if/beringei_query.thrift
+++ b/beringei/if/beringei_query.thrift
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-namespace cpp2 facebook.gorilla
+namespace cpp2 facebook.gorilla.query
 namespace py facebook.gorilla.beringei_query
 
 struct KeyData {

--- a/beringei/if/beringei_query.thrift
+++ b/beringei/if/beringei_query.thrift
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+namespace cpp2 facebook.gorilla
+namespace py facebook.gorilla.beringei_query
+
+struct KeyData {
+  1: i64 keyId,
+  2: string key,
+  10: optional string displayName,
+  11: optional string linkName,
+  20: optional string node,
+  21: optional string nodeName,
+  30: optional string siteName,
+}
+
+struct Query {
+  1: string type,
+  2: list<i64> key_ids,
+  3: list<KeyData> data,
+  4: optional i32 min_ago,
+  5: string agg_type,
+
+  // period to search (unixtime)
+  10: i64 start_ts,
+  11: i64 end_ts,
+}
+
+struct QueryRequest {
+  1: list<Query> queries,
+}

--- a/beringei/if/beringei_query.thrift
+++ b/beringei/if/beringei_query.thrift
@@ -40,3 +40,33 @@ struct Query {
 struct QueryRequest {
   1: list<Query> queries,
 }
+
+struct Stat {
+  1: string key,
+  2: i64 ts,
+  3: double value,
+}
+
+struct Agent {
+  1: string mac,
+  2: string name,
+  3: string site,
+  4: list<Stat> stats,
+}
+
+struct Topology {
+  1: string name,
+}
+
+struct WriteRequest {
+  1: Topology topology,
+  2: list<Agent> agents,
+}
+
+struct MySqlNodeData {
+  1: i64 id,
+  2: string node,
+  3: string mac,
+  4: string network,
+  5: string site,
+}

--- a/beringei/if/beringei_query.thrift
+++ b/beringei/if/beringei_query.thrift
@@ -47,20 +47,56 @@ struct Stat {
   3: double value,
 }
 
-struct Agent {
+struct Event {
+  1: string category,
+  2: i64 ts,
+  3: string sample,
+}
+
+struct Log {
+  1: i64 ts,
+  2: string file,
+  3: string log,
+}
+
+struct NodeStates {
   1: string mac,
   2: string name,
   3: string site,
   4: list<Stat> stats,
 }
 
+struct NodeLogs {
+  1: string mac,
+  2: string name,
+  3: string site,
+  4: list<Log> logs,
+}
+
+struct NodeEvents {
+  1: string mac,
+  2: string name,
+  3: string site,
+  4: list<Event> events,
+}
+
 struct Topology {
   1: string name,
 }
 
-struct WriteRequest {
+struct StatsWriteRequest {
   1: Topology topology,
-  2: list<Agent> agents,
+  2: list<NodeStates> agents,
+}
+
+struct LogsWriteRequest {
+  1: Topology topology,
+  2: list<NodeLogs> agents,
+}
+
+struct EventsWriteRequest {
+  1: Topology topology,
+  2: list<NodeEvents> agents,
 }
 
 struct MySqlNodeData {
@@ -69,4 +105,37 @@ struct MySqlNodeData {
   3: string mac,
   4: string network,
   5: string site,
+}
+
+struct MySqlEventData {
+  1: string sample,
+  2: string timestamp,
+  3: i64 category_id,
+}
+
+struct AlertsWriteRequest {
+  1: i64 timestamp,
+  2: string node_mac,
+  3: string node_name,
+  4: string node_site,
+  5: string node_topology,
+  6: string alert_id,
+  7: string alert_regex,
+  8: double alert_threshold,
+  9: string alert_comparator,
+  10: string alert_level,
+  11: string trigger_key,
+  12: double trigger_value,
+}
+
+struct MySqlAlertData {
+  1: i64 node_id,
+  2: string timestamp,
+  3: string alert_id,
+  4: string alert_regex,
+  5: double alert_threshold,
+  6: string alert_comparator,
+  7: string alert_level,
+  8: string trigger_key,
+  9: double trigger_value,
 }

--- a/beringei/if/beringei_query.thrift
+++ b/beringei/if/beringei_query.thrift
@@ -13,10 +13,15 @@ namespace py facebook.gorilla.beringei_query
 struct KeyData {
   1: i64 keyId,
   2: string key,
+
   10: optional string displayName,
   11: optional string linkName,
+  // extra title for link
+  12: optional string linkTitleAppend,
+
   20: optional string node,
   21: optional string nodeName,
+
   30: optional string siteName,
 }
 

--- a/beringei/if/beringei_query.thrift
+++ b/beringei/if/beringei_query.thrift
@@ -40,33 +40,3 @@ struct Query {
 struct QueryRequest {
   1: list<Query> queries,
 }
-
-struct Stat {
-  1: string key,
-  2: i64 ts,
-  3: double value,
-}
-
-struct Agent {
-  1: string mac,
-  2: string name,
-  3: string site,
-  4: list<Stat> stats,
-}
-
-struct Topology {
-  1: string name,
-}
-
-struct WriteRequest {
-  1: Topology topology,
-  2: list<Agent> agents,
-}
-
-struct MySqlNodeData {
-  1: i64 id,
-  2: string node,
-  3: string mac,
-  4: string network,
-  5: string site,
-}

--- a/beringei/if/beringei_query.thrift
+++ b/beringei/if/beringei_query.thrift
@@ -49,14 +49,14 @@ struct Stat {
 
 struct Event {
   1: string category,
-  2: i64 ts,
+  2: i64 ts, /* Timestamp in us */
   3: string sample,
 }
 
 struct Log {
-  1: i64 ts,
-  2: string file,
-  3: string log,
+  1: i64 ts, /* Timestamp in us */
+  2: string file, /* Filename */
+  3: string log, /* Log line */
 }
 
 struct NodeStates {
@@ -109,7 +109,7 @@ struct MySqlNodeData {
 
 struct MySqlEventData {
   1: string sample,
-  2: string timestamp,
+  2: i64 timestamp,
   3: i64 category_id,
 }
 
@@ -130,7 +130,7 @@ struct AlertsWriteRequest {
 
 struct MySqlAlertData {
   1: i64 node_id,
-  2: string timestamp,
+  2: i64 timestamp,
   3: string alert_id,
   4: string alert_regex,
   5: double alert_threshold,

--- a/beringei/tools/CMakeLists.txt
+++ b/beringei/tools/CMakeLists.txt
@@ -55,4 +55,4 @@ target_link_libraries(
     Threads::Threads
 )
 
-add_subdirectory(grafana_read_service)
+add_subdirectory(query_service)

--- a/beringei/tools/query_service/AlertsWriteHandler.cpp
+++ b/beringei/tools/query_service/AlertsWriteHandler.cpp
@@ -56,8 +56,8 @@ int64_t AlertsWriteHandler::getTimestamp(int64_t timeInUsec) {
   return std::time(nullptr);
 }
 
-void AlertsWriteHandler::writeData(AlertsWriteRequest request) {
-  std::unordered_map<std::string, MySqlNodeData> unknownNodes;
+void AlertsWriteHandler::writeData(query::AlertsWriteRequest request) {
+  std::unordered_map<std::string, query::MySqlNodeData> unknownNodes;
 
   auto startTime = (int64_t)duration_cast<milliseconds>(
                        system_clock::now().time_since_epoch())
@@ -65,7 +65,7 @@ void AlertsWriteHandler::writeData(AlertsWriteRequest request) {
 
   auto nodeId = mySqlClient_->getNodeId(request.node_mac);
   if (!nodeId) {
-    MySqlNodeData newNode;
+    query::MySqlNodeData newNode;
     newNode.mac = request.node_mac;
     newNode.node = request.node_name;
     newNode.site = request.node_site;
@@ -76,7 +76,7 @@ void AlertsWriteHandler::writeData(AlertsWriteRequest request) {
     return;
   }
 
-  MySqlAlertData row;
+  query::MySqlAlertData row;
   row.node_id = *nodeId;
   row.timestamp = getTimestamp(request.timestamp);
   row.alert_id = request.alert_id;
@@ -101,9 +101,9 @@ void AlertsWriteHandler::writeData(AlertsWriteRequest request) {
 
 void AlertsWriteHandler::onEOM() noexcept {
   auto body = body_->moveToFbString();
-  AlertsWriteRequest request;
+  query::AlertsWriteRequest request;
   try {
-    request = SimpleJSONSerializer::deserialize<AlertsWriteRequest>(body);
+    request = SimpleJSONSerializer::deserialize<query::AlertsWriteRequest>(body);
   } catch (const std::exception&) {
     LOG(INFO) << "Error deserializing alerts_writer request";
     ResponseBuilder(downstream_)
@@ -147,6 +147,6 @@ void AlertsWriteHandler::onError(ProxygenError /* unused */) noexcept {
   delete this;
 }
 
-void AlertsWriteHandler::logRequest(AlertsWriteRequest request) {}
+void AlertsWriteHandler::logRequest(query::AlertsWriteRequest request) {}
 }
 } // facebook::gorilla

--- a/beringei/tools/query_service/AlertsWriteHandler.cpp
+++ b/beringei/tools/query_service/AlertsWriteHandler.cpp
@@ -1,0 +1,165 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "AlertsWriteHandler.h"
+
+#include <ctime>
+#include <utility>
+
+#include <folly/DynamicConverter.h>
+#include <folly/io/IOBuf.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include <thrift/lib/cpp/util/ThriftSerializer.h>
+#include <thrift/lib/cpp2/protocol/Serializer.h>
+
+#include "mysql_connection.h"
+#include "mysql_driver.h"
+
+#include <cppconn/driver.h>
+#include <cppconn/exception.h>
+#include <cppconn/prepared_statement.h>
+#include <cppconn/resultset.h>
+#include <cppconn/statement.h>
+
+#include <algorithm>
+
+using apache::thrift::SimpleJSONSerializer;
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::microseconds;
+using std::chrono::system_clock;
+using namespace proxygen;
+
+namespace facebook {
+namespace gorilla {
+
+AlertsWriteHandler::AlertsWriteHandler(std::shared_ptr<MySqlClient> mySqlClient)
+    : RequestHandler(), mySqlClient_(mySqlClient) {}
+
+void AlertsWriteHandler::onRequest(
+    std::unique_ptr<HTTPMessage> /* unused */) noexcept {
+  // nothing to do
+}
+
+void AlertsWriteHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept {
+  if (body_) {
+    body_->prependChain(move(body));
+  } else {
+    body_ = move(body);
+  }
+}
+
+std::string AlertsWriteHandler::getMySqlTimestamp(int64_t timeInUsec) {
+  time_t curr_time;
+  tm* curr_tm;
+  char date_string[100];
+
+  time(&curr_time);
+  curr_tm = localtime(&curr_time);
+
+  strftime(date_string, 50, "%Y-%m-%d %X", curr_tm);
+  return std::string(date_string);
+}
+
+void AlertsWriteHandler::writeData(AlertsWriteRequest request) {
+  std::unordered_map<std::string, MySqlNodeData> unknownNodes;
+
+  auto startTime = (int64_t)duration_cast<milliseconds>(
+                       system_clock::now().time_since_epoch())
+                       .count();
+
+  auto nodeId = mySqlClient_->getNodeId(request.node_mac);
+  if (!nodeId) {
+    MySqlNodeData newNode;
+    newNode.mac = request.node_mac;
+    newNode.node = request.node_name;
+    newNode.site = request.node_site;
+    newNode.network = request.node_topology;
+    unknownNodes[newNode.mac] = newNode;
+    LOG(INFO) << "Unknown mac: " << request.node_mac;
+    mySqlClient_->addNodes(unknownNodes);
+    return;
+  }
+
+  std::string tsParsed = getMySqlTimestamp(request.timestamp);
+  MySqlAlertData row;
+  row.node_id = *nodeId;
+  row.timestamp = tsParsed;
+  row.alert_id = request.alert_id;
+  row.alert_regex = request.alert_regex;
+  row.alert_threshold = request.alert_threshold;
+  row.alert_comparator = request.alert_comparator;
+  row.alert_level = request.alert_level;
+  row.trigger_key = request.trigger_key;
+  row.trigger_value = request.trigger_value;
+
+  folly::EventBase eb;
+  eb.runInLoop([this, &row]() mutable { mySqlClient_->addAlert(row); });
+  std::thread tEb([&eb]() { eb.loop(); });
+  tEb.join();
+
+  auto endTime = (int64_t)duration_cast<milliseconds>(
+                     system_clock::now().time_since_epoch())
+                     .count();
+  LOG(INFO) << "Writeing alerts complete. "
+            << "Total: " << (endTime - startTime) << "ms.";
+}
+
+void AlertsWriteHandler::onEOM() noexcept {
+  auto body = body_->moveToFbString();
+  AlertsWriteRequest request;
+  try {
+    request = SimpleJSONSerializer::deserialize<AlertsWriteRequest>(body);
+  } catch (const std::exception&) {
+    LOG(INFO) << "Error deserializing alerts_writer request";
+    ResponseBuilder(downstream_)
+        .status(500, "OK")
+        .header("Content-Type", "application/json")
+        .body("Failed de-serializing alerts_writer request")
+        .sendWithEOM();
+    return;
+  }
+  logRequest(request);
+  LOG(INFO) << "Alerts writer request from \"" << request.node_topology << "\"";
+
+  folly::fbstring jsonResp;
+  try {
+    writeData(request);
+  } catch (const std::exception& ex) {
+    LOG(ERROR) << "Unable to handle alerts_writer request: " << ex.what();
+    ResponseBuilder(downstream_)
+        .status(500, "OK")
+        .header("Content-Type", "application/json")
+        .body("Failed handling alerts_writer request")
+        .sendWithEOM();
+    return;
+  }
+  ResponseBuilder(downstream_)
+      .status(200, "OK")
+      .header("Content-Type", "application/json")
+      .body(jsonResp)
+      .sendWithEOM();
+}
+
+void AlertsWriteHandler::onUpgrade(UpgradeProtocol /* unused */) noexcept {}
+
+void AlertsWriteHandler::requestComplete() noexcept {
+  delete this;
+}
+
+void AlertsWriteHandler::onError(ProxygenError /* unused */) noexcept {
+  LOG(ERROR) << "Proxygen reported error";
+  // In QueryServiceFactory, we created this handler using new.
+  // Proxygen does not delete the handler.
+  delete this;
+}
+
+void AlertsWriteHandler::logRequest(AlertsWriteRequest request) {}
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/AlertsWriteHandler.h
+++ b/beringei/tools/query_service/AlertsWriteHandler.h
@@ -43,7 +43,7 @@ class AlertsWriteHandler : public proxygen::RequestHandler {
 
   void writeData(AlertsWriteRequest request);
 
-  std::string getMySqlTimestamp(int64_t timeInUsec);
+  int64_t getTimestamp(int64_t timeInUsec);
 
   std::shared_ptr<MySqlClient> mySqlClient_;
   std::unique_ptr<folly::IOBuf> body_;

--- a/beringei/tools/query_service/AlertsWriteHandler.h
+++ b/beringei/tools/query_service/AlertsWriteHandler.h
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include "MySqlClient.h"
+
+#include <folly/Memory.h>
+#include <folly/dynamic.h>
+#include <folly/futures/Future.h>
+#include <proxygen/httpserver/RequestHandler.h>
+
+#include "beringei/if/gen-cpp2/beringei_query_types_custom_protocol.h"
+
+namespace facebook {
+namespace gorilla {
+
+class AlertsWriteHandler : public proxygen::RequestHandler {
+ public:
+  explicit AlertsWriteHandler(std::shared_ptr<MySqlClient> mySqlClient);
+
+  void onRequest(
+      std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override;
+
+  void onBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
+
+  void onEOM() noexcept override;
+
+  void onUpgrade(proxygen::UpgradeProtocol proto) noexcept override;
+
+  void requestComplete() noexcept override;
+
+  void onError(proxygen::ProxygenError err) noexcept override;
+
+ private:
+  void logRequest(AlertsWriteRequest request);
+
+  void writeData(AlertsWriteRequest request);
+
+  std::string getMySqlTimestamp(int64_t timeInUsec);
+
+  std::shared_ptr<MySqlClient> mySqlClient_;
+  std::unique_ptr<folly::IOBuf> body_;
+};
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/AlertsWriteHandler.h
+++ b/beringei/tools/query_service/AlertsWriteHandler.h
@@ -39,9 +39,9 @@ class AlertsWriteHandler : public proxygen::RequestHandler {
   void onError(proxygen::ProxygenError err) noexcept override;
 
  private:
-  void logRequest(AlertsWriteRequest request);
+  void logRequest(query::AlertsWriteRequest request);
 
-  void writeData(AlertsWriteRequest request);
+  void writeData(query::AlertsWriteRequest request);
 
   int64_t getTimestamp(int64_t timeInUsec);
 

--- a/beringei/tools/query_service/BeringeiQueryServer.cpp
+++ b/beringei/tools/query_service/BeringeiQueryServer.cpp
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <unistd.h>
+
+#include "QueryServiceFactory.h"
+
+#include <folly/Memory.h>
+#include <folly/init/Init.h>
+#include <folly/io/async/EventBaseManager.h>
+#include <gflags/gflags.h>
+#include <proxygen/httpserver/HTTPServer.h>
+#include <proxygen/httpserver/RequestHandlerFactory.h>
+
+using namespace proxygen;
+using namespace facebook::gorilla;
+
+using folly::EventBase;
+using folly::EventBaseManager;
+using folly::SocketAddress;
+
+using Protocol = HTTPServer::Protocol;
+DEFINE_int32(http_port, 443, "Port to listen on with HTTP protocol");
+DEFINE_string(ip, "::", "IP/Hostname to bind to");
+DEFINE_int32(
+    threads,
+    0,
+    "Number of threads to listen on. Numbers <= 0 "
+    "will use the number of cores on this machine.");
+
+int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv, true);
+  google::InstallFailureSignalHandler();
+
+  LOG(INFO) << "Attemping to bind to port " << FLAGS_http_port;
+
+  std::vector<HTTPServer::IPConfig> IPs = {
+      {SocketAddress(FLAGS_ip, FLAGS_http_port, true), Protocol::HTTP},
+  };
+
+  if (FLAGS_threads <= 0) {
+    FLAGS_threads = sysconf(_SC_NPROCESSORS_ONLN);
+    CHECK_GT(FLAGS_threads, 0);
+  }
+
+  HTTPServerOptions options;
+  options.threads = static_cast<size_t>(FLAGS_threads);
+  options.idleTimeout = std::chrono::milliseconds(60000);
+  options.shutdownOn = {SIGINT, SIGTERM};
+  options.enableContentCompression = false;
+  options.handlerFactories =
+      RequestHandlerChain().addThen<QueryServiceFactory>().build();
+
+  LOG(INFO) << "Starting Beringei-Grafana server on port " << FLAGS_http_port;
+  auto server = std::make_shared<HTTPServer>(std::move(options));
+  server->bind(IPs);
+  std::thread t([server]() { server->start(); });
+
+  t.join();
+  return 0;
+}

--- a/beringei/tools/query_service/CMakeLists.txt
+++ b/beringei/tools/query_service/CMakeLists.txt
@@ -12,10 +12,6 @@ set(BERINGEI_QUERY_SRCS
     NotFoundHandler.h
     QueryHandler.h
     QueryHandler.cpp
-    WriteHandler.h
-    WriteHandler.cpp
-    MySqlClient.cpp
-    MySqlClient.h
 )
 
 set(BERINGEI_QUERY_SERVICE_SRCS
@@ -33,8 +29,6 @@ target_link_libraries(
     ${LIBGLOG_LIBRARIES}
     ${PROXYGEN_LIBRARIES}
     Threads::Threads
-    mysqlclient
-    mysqlcppconn
 )
 
 add_executable(beringei_query_service ${BERINGEI_QUERY_SERVICE_SRCS})

--- a/beringei/tools/query_service/CMakeLists.txt
+++ b/beringei/tools/query_service/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+set(BERINGEI_QUERY_SRCS
+    QueryServiceFactory.cpp
+    QueryServiceFactory.h
+    NotFoundHandler.cpp
+    NotFoundHandler.h
+    QueryHandler.h
+    QueryHandler.cpp
+)
+
+set(BERINGEI_QUERY_SERVICE_SRCS
+  BeringeiQueryServer.cpp
+)
+
+add_library(beringei_query_lib STATIC ${BERINGEI_QUERY_SRCS})
+target_link_libraries(
+    beringei_query_lib
+    beringei_client
+    beringei_plugin
+    ${FBTHRIFT_LIBRARIES}
+    ${FOLLY_LIBRARIES}
+    ${GFLAGS_LIBRARIES}
+    ${LIBGLOG_LIBRARIES}
+    ${PROXYGEN_LIBRARIES}
+    Threads::Threads
+)
+
+add_executable(beringei_query_service ${BERINGEI_QUERY_SERVICE_SRCS})
+
+target_link_libraries(
+    beringei_query_service
+    beringei_query_lib
+    ${FBTHRIFT_LIBRARIES}
+    ${FOLLY_LIBRARIES}
+    ${GFLAGS_LIBRARIES}
+    ${LIBGLOG_LIBRARIES}
+    ${PROXYGEN_LIBRARIES}
+    Threads::Threads
+)

--- a/beringei/tools/query_service/CMakeLists.txt
+++ b/beringei/tools/query_service/CMakeLists.txt
@@ -10,12 +10,18 @@ set(BERINGEI_QUERY_SRCS
     QueryServiceFactory.h
     NotFoundHandler.cpp
     NotFoundHandler.h
-    QueryHandler.h
     QueryHandler.cpp
-    WriteHandler.h
-    WriteHandler.cpp
+    QueryHandler.h
+    StatsWriteHandler.cpp
+    StatsWriteHandler.h
     MySqlClient.cpp
     MySqlClient.h
+    EventsWriteHandler.cpp
+    EventsWriteHandler.h
+    AlertsWriteHandler.cpp
+    AlertsWriteHandler.h
+    LogsWriteHandler.cpp
+    LogsWriteHandler.h
 )
 
 set(BERINGEI_QUERY_SERVICE_SRCS

--- a/beringei/tools/query_service/CMakeLists.txt
+++ b/beringei/tools/query_service/CMakeLists.txt
@@ -12,6 +12,10 @@ set(BERINGEI_QUERY_SRCS
     NotFoundHandler.h
     QueryHandler.h
     QueryHandler.cpp
+    WriteHandler.h
+    WriteHandler.cpp
+    MySqlClient.cpp
+    MySqlClient.h
 )
 
 set(BERINGEI_QUERY_SERVICE_SRCS
@@ -29,6 +33,8 @@ target_link_libraries(
     ${LIBGLOG_LIBRARIES}
     ${PROXYGEN_LIBRARIES}
     Threads::Threads
+    mysqlclient
+    mysqlcppconn
 )
 
 add_executable(beringei_query_service ${BERINGEI_QUERY_SERVICE_SRCS})

--- a/beringei/tools/query_service/CMakeLists.txt
+++ b/beringei/tools/query_service/CMakeLists.txt
@@ -5,6 +5,11 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+find_library(MYSQL_CLIENT_LIB NAMES "mysqlclient"
+  PATHS "/usr/local/mysql/lib"
+  NO_DEFAULT_PATH
+)
+
 set(BERINGEI_QUERY_SRCS
     QueryServiceFactory.cpp
     QueryServiceFactory.h
@@ -12,6 +17,10 @@ set(BERINGEI_QUERY_SRCS
     NotFoundHandler.h
     QueryHandler.h
     QueryHandler.cpp
+    WriteHandler.h
+    WriteHandler.cpp
+    MySqlClient.cpp
+    MySqlClient.h
 )
 
 set(BERINGEI_QUERY_SERVICE_SRCS
@@ -29,6 +38,8 @@ target_link_libraries(
     ${LIBGLOG_LIBRARIES}
     ${PROXYGEN_LIBRARIES}
     Threads::Threads
+    ${MYSQL_CLIENT_LIB}
+    mysqlcppconn
 )
 
 add_executable(beringei_query_service ${BERINGEI_QUERY_SERVICE_SRCS})

--- a/beringei/tools/query_service/EventsWriteHandler.cpp
+++ b/beringei/tools/query_service/EventsWriteHandler.cpp
@@ -56,11 +56,11 @@ int64_t EventsWriteHandler::getTimestamp(int64_t timeInUsec) {
   return std::time(nullptr);
 }
 
-void EventsWriteHandler::writeData(EventsWriteRequest request) {
-  std::unordered_map<std::string, MySqlNodeData> unknownNodes;
+void EventsWriteHandler::writeData(query::EventsWriteRequest request) {
+  std::unordered_map<std::string, query::MySqlNodeData> unknownNodes;
   std::unordered_map<int64_t, std::unordered_set<std::string>>
       missingEventCategories;
-  std::vector<MySqlEventData> eventsRows;
+  std::vector<query::MySqlEventData> eventsRows;
 
   auto startTime = (int64_t)duration_cast<milliseconds>(
                        system_clock::now().time_since_epoch())
@@ -69,7 +69,7 @@ void EventsWriteHandler::writeData(EventsWriteRequest request) {
   for (const auto& agent : request.agents) {
     auto nodeId = mySqlClient_->getNodeId(agent.mac);
     if (!nodeId) {
-      MySqlNodeData newNode;
+      query::MySqlNodeData newNode;
       newNode.mac = agent.mac;
       newNode.node = agent.name;
       newNode.site = agent.site;
@@ -85,7 +85,7 @@ void EventsWriteHandler::writeData(EventsWriteRequest request) {
       // verify node/category combo exists
       if (eventCategoryId) {
         // insert row for beringei
-        MySqlEventData eventsRow;
+        query::MySqlEventData eventsRow;
         eventsRow.sample = event.sample;
         eventsRow.timestamp = getTimestamp(event.ts);;
         eventsRow.category_id = *eventCategoryId;
@@ -119,9 +119,9 @@ void EventsWriteHandler::writeData(EventsWriteRequest request) {
 
 void EventsWriteHandler::onEOM() noexcept {
   auto body = body_->moveToFbString();
-  EventsWriteRequest request;
+  query::EventsWriteRequest request;
   try {
-    request = SimpleJSONSerializer::deserialize<EventsWriteRequest>(body);
+    request = SimpleJSONSerializer::deserialize<query::EventsWriteRequest>(body);
   } catch (const std::exception&) {
     LOG(INFO) << "Error deserializing events_writer request";
     ResponseBuilder(downstream_)
@@ -166,6 +166,6 @@ void EventsWriteHandler::onError(ProxygenError /* unused */) noexcept {
   delete this;
 }
 
-void EventsWriteHandler::logRequest(EventsWriteRequest request) {}
+void EventsWriteHandler::logRequest(query::EventsWriteRequest request) {}
 }
 } // facebook::gorilla

--- a/beringei/tools/query_service/EventsWriteHandler.cpp
+++ b/beringei/tools/query_service/EventsWriteHandler.cpp
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "EventsWriteHandler.h"
+
+#include <ctime>
+#include <utility>
+
+#include <folly/DynamicConverter.h>
+#include <folly/io/IOBuf.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include <thrift/lib/cpp/util/ThriftSerializer.h>
+#include <thrift/lib/cpp2/protocol/Serializer.h>
+
+#include "mysql_connection.h"
+#include "mysql_driver.h"
+
+#include <cppconn/driver.h>
+#include <cppconn/exception.h>
+#include <cppconn/prepared_statement.h>
+#include <cppconn/resultset.h>
+#include <cppconn/statement.h>
+
+#include <algorithm>
+
+using apache::thrift::SimpleJSONSerializer;
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::microseconds;
+using std::chrono::system_clock;
+using namespace proxygen;
+
+namespace facebook {
+namespace gorilla {
+
+EventsWriteHandler::EventsWriteHandler(std::shared_ptr<MySqlClient> mySqlClient)
+    : RequestHandler(), mySqlClient_(mySqlClient) {}
+
+void EventsWriteHandler::onRequest(
+    std::unique_ptr<HTTPMessage> /* unused */) noexcept {
+  // nothing to do
+}
+
+void EventsWriteHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept {
+  if (body_) {
+    body_->prependChain(move(body));
+  } else {
+    body_ = move(body);
+  }
+}
+
+std::string EventsWriteHandler::getMySqlTimestamp(int64_t timeInUsec) {
+  time_t curr_time;
+  tm* curr_tm;
+  char date_string[100];
+
+  time(&curr_time);
+  curr_tm = localtime(&curr_time);
+
+  strftime(date_string, 50, "%Y-%m-%d %X", curr_tm);
+  return std::string(date_string);
+}
+
+void EventsWriteHandler::writeData(EventsWriteRequest request) {
+  std::unordered_map<std::string, MySqlNodeData> unknownNodes;
+  std::unordered_map<int64_t, std::unordered_set<std::string>>
+      missingEventCategories;
+  std::vector<MySqlEventData> eventsRows;
+
+  auto startTime = (int64_t)duration_cast<milliseconds>(
+                       system_clock::now().time_since_epoch())
+                       .count();
+
+  for (const auto& agent : request.agents) {
+    auto nodeId = mySqlClient_->getNodeId(agent.mac);
+    if (!nodeId) {
+      MySqlNodeData newNode;
+      newNode.mac = agent.mac;
+      newNode.node = agent.name;
+      newNode.site = agent.site;
+      newNode.network = request.topology.name;
+      unknownNodes[newNode.mac] = newNode;
+      LOG(INFO) << "Unknown mac: " << agent.mac;
+      continue;
+    }
+
+    for (const auto& event : agent.events) {
+      // check timestamp
+      std::string tsParsed = getMySqlTimestamp(event.ts);
+      auto eventCategoryId =
+          mySqlClient_->getEventCategoryId(*nodeId, event.category);
+      // verify node/category combo exists
+      if (eventCategoryId) {
+        // insert row for beringei
+        MySqlEventData eventsRow;
+        eventsRow.sample = event.sample;
+        eventsRow.timestamp = tsParsed;
+        eventsRow.category_id = *eventCategoryId;
+        eventsRows.push_back(eventsRow);
+      } else {
+        LOG(INFO) << "Missing cache for " << *nodeId << "/" << event.category;
+        missingEventCategories[*nodeId].insert(event.category);
+      }
+    }
+  }
+  // write newly found macs and node/key combos
+  mySqlClient_->addNodes(unknownNodes);
+  mySqlClient_->addEventCategories(missingEventCategories);
+
+  if (eventsRows.size()) {
+    folly::EventBase eb;
+    eb.runInLoop(
+        [this, &eventsRows]() mutable { mySqlClient_->addEvents(eventsRows); });
+    std::thread tEb([&eb]() { eb.loop(); });
+    tEb.join();
+
+    auto endTime = (int64_t)duration_cast<milliseconds>(
+                       system_clock::now().time_since_epoch())
+                       .count();
+    LOG(INFO) << "Writing events complete. "
+              << "Total: " << (endTime - startTime) << "ms.";
+  } else {
+    LOG(INFO) << "No events data to write!";
+  }
+}
+
+void EventsWriteHandler::onEOM() noexcept {
+  auto body = body_->moveToFbString();
+  EventsWriteRequest request;
+  try {
+    request = SimpleJSONSerializer::deserialize<EventsWriteRequest>(body);
+  } catch (const std::exception&) {
+    LOG(INFO) << "Error deserializing events_writer request";
+    ResponseBuilder(downstream_)
+        .status(500, "OK")
+        .header("Content-Type", "application/json")
+        .body("Failed de-serializing events_writer request")
+        .sendWithEOM();
+    return;
+  }
+  logRequest(request);
+  LOG(INFO) << "Events writer request from \"" << request.topology.name
+            << "\" for " << request.agents.size() << " nodes";
+
+  folly::fbstring jsonResp;
+  try {
+    writeData(request);
+  } catch (const std::exception& ex) {
+    LOG(ERROR) << "Unable to handle events_writer request: " << ex.what();
+    ResponseBuilder(downstream_)
+        .status(500, "OK")
+        .header("Content-Type", "application/json")
+        .body("Failed handling events_writer request")
+        .sendWithEOM();
+    return;
+  }
+  ResponseBuilder(downstream_)
+      .status(200, "OK")
+      .header("Content-Type", "application/json")
+      .body(jsonResp)
+      .sendWithEOM();
+}
+
+void EventsWriteHandler::onUpgrade(UpgradeProtocol /* unused */) noexcept {}
+
+void EventsWriteHandler::requestComplete() noexcept {
+  delete this;
+}
+
+void EventsWriteHandler::onError(ProxygenError /* unused */) noexcept {
+  LOG(ERROR) << "Proxygen reported error";
+  // In QueryServiceFactory, we created this handler using new.
+  // Proxygen does not delete the handler.
+  delete this;
+}
+
+void EventsWriteHandler::logRequest(EventsWriteRequest request) {}
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/EventsWriteHandler.h
+++ b/beringei/tools/query_service/EventsWriteHandler.h
@@ -39,9 +39,9 @@ class EventsWriteHandler : public proxygen::RequestHandler {
   void onError(proxygen::ProxygenError err) noexcept override;
 
  private:
-  void logRequest(EventsWriteRequest request);
+  void logRequest(query::EventsWriteRequest request);
 
-  void writeData(EventsWriteRequest request);
+  void writeData(query::EventsWriteRequest request);
 
   int64_t getTimestamp(int64_t timeInUsec);
 

--- a/beringei/tools/query_service/EventsWriteHandler.h
+++ b/beringei/tools/query_service/EventsWriteHandler.h
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include "MySqlClient.h"
+
+#include <folly/Memory.h>
+#include <folly/dynamic.h>
+#include <folly/futures/Future.h>
+#include <proxygen/httpserver/RequestHandler.h>
+
+#include "beringei/if/gen-cpp2/beringei_query_types_custom_protocol.h"
+
+namespace facebook {
+namespace gorilla {
+
+class EventsWriteHandler : public proxygen::RequestHandler {
+ public:
+  explicit EventsWriteHandler(std::shared_ptr<MySqlClient> mySqlClient);
+
+  void onRequest(
+      std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override;
+
+  void onBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
+
+  void onEOM() noexcept override;
+
+  void onUpgrade(proxygen::UpgradeProtocol proto) noexcept override;
+
+  void requestComplete() noexcept override;
+
+  void onError(proxygen::ProxygenError err) noexcept override;
+
+ private:
+  void logRequest(EventsWriteRequest request);
+
+  void writeData(EventsWriteRequest request);
+
+  std::string getMySqlTimestamp(int64_t timeInUsec);
+
+  std::shared_ptr<MySqlClient> mySqlClient_;
+  std::unique_ptr<folly::IOBuf> body_;
+};
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/EventsWriteHandler.h
+++ b/beringei/tools/query_service/EventsWriteHandler.h
@@ -43,7 +43,7 @@ class EventsWriteHandler : public proxygen::RequestHandler {
 
   void writeData(EventsWriteRequest request);
 
-  std::string getMySqlTimestamp(int64_t timeInUsec);
+  int64_t getTimestamp(int64_t timeInUsec);
 
   std::shared_ptr<MySqlClient> mySqlClient_;
   std::unique_ptr<folly::IOBuf> body_;

--- a/beringei/tools/query_service/LogsWriteHandler.cpp
+++ b/beringei/tools/query_service/LogsWriteHandler.cpp
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "LogsWriteHandler.h"
+
+#include <ctime>
+#include <fstream>
+#include <utility>
+
+#include <errno.h>
+#include <folly/DynamicConverter.h>
+#include <folly/io/IOBuf.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include <sys/stat.h>
+#include <thrift/lib/cpp/util/ThriftSerializer.h>
+#include <thrift/lib/cpp2/protocol/Serializer.h>
+
+#include <algorithm>
+
+using apache::thrift::SimpleJSONSerializer;
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::microseconds;
+using std::chrono::system_clock;
+using namespace proxygen;
+
+DEFINE_string(data_folder_path, "/home/nms/data/", "Path to data folder");
+
+namespace facebook {
+namespace gorilla {
+
+LogsWriteHandler::LogsWriteHandler() : RequestHandler() {}
+
+void LogsWriteHandler::onRequest(
+    std::unique_ptr<HTTPMessage> /* unused */) noexcept {
+  // nothing to do
+}
+
+void LogsWriteHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept {
+  if (body_) {
+    body_->prependChain(move(body));
+  } else {
+    body_ = move(body);
+  }
+}
+
+void LogsWriteHandler::writeData(LogsWriteRequest request) {
+  auto startTime = (int64_t)duration_cast<milliseconds>(
+                       system_clock::now().time_since_epoch())
+                       .count();
+  time_t curr_time;
+  tm* curr_tm;
+  char date_string[100];
+  time(&curr_time);
+  curr_tm = localtime(&curr_time);
+  strftime(date_string, 50, "%m-%d-%Y", curr_tm);
+  std::string day(date_string);
+
+  for (const auto& agent : request.agents) {
+    std::string folder = FLAGS_data_folder_path + agent.mac + '/';
+    errno = 0;
+    const int dir_err =
+        mkdir(folder.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    if (-1 == dir_err && errno != EEXIST) {
+      LOG(ERROR) << "Error creating directory " << folder;
+      continue;
+    }
+    for (const auto& logMsg : agent.logs) {
+      std::string fileName = folder + day + '_' + logMsg.file + ".log";
+      std::ofstream outfile;
+      outfile.open(fileName, std::ios_base::app);
+      if (outfile) {
+        outfile << logMsg.log << "\n";
+      } else {
+        LOG(ERROR) << "Unable to open file " << fileName;
+      }
+    }
+  }
+  auto endTime = (int64_t)duration_cast<milliseconds>(
+                     system_clock::now().time_since_epoch())
+                     .count();
+  LOG(INFO) << "Writing logs complete. "
+            << "Total: " << (endTime - startTime) << "ms.";
+}
+
+void LogsWriteHandler::onEOM() noexcept {
+  auto body = body_->moveToFbString();
+  LogsWriteRequest request;
+  try {
+    request = SimpleJSONSerializer::deserialize<LogsWriteRequest>(body);
+  } catch (const std::exception&) {
+    LOG(INFO) << "Error deserializing logs_writer request";
+    ResponseBuilder(downstream_)
+        .status(500, "OK")
+        .header("Content-Type", "application/json")
+        .body("Failed de-serializing logs_writer request")
+        .sendWithEOM();
+    return;
+  }
+  logRequest(request);
+  LOG(INFO) << "Logs writer request from \"" << request.topology.name
+            << "\" for " << request.agents.size() << " nodes";
+
+  folly::fbstring jsonResp;
+  try {
+    writeData(request);
+  } catch (const std::exception& ex) {
+    LOG(ERROR) << "Unable to handle logs_writer request: " << ex.what();
+    ResponseBuilder(downstream_)
+        .status(500, "OK")
+        .header("Content-Type", "application/json")
+        .body("Failed handling logs_writer request")
+        .sendWithEOM();
+    return;
+  }
+  ResponseBuilder(downstream_)
+      .status(200, "OK")
+      .header("Content-Type", "application/json")
+      .body(jsonResp)
+      .sendWithEOM();
+}
+
+void LogsWriteHandler::onUpgrade(UpgradeProtocol /* unused */) noexcept {}
+
+void LogsWriteHandler::requestComplete() noexcept {
+  delete this;
+}
+
+void LogsWriteHandler::onError(ProxygenError /* unused */) noexcept {
+  LOG(ERROR) << "Proxygen reported error";
+  // In QueryServiceFactory, we created this handler using new.
+  // Proxygen does not delete the handler.
+  delete this;
+}
+
+void LogsWriteHandler::logRequest(LogsWriteRequest request) {}
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/LogsWriteHandler.cpp
+++ b/beringei/tools/query_service/LogsWriteHandler.cpp
@@ -9,6 +9,7 @@
 
 #include "LogsWriteHandler.h"
 
+#include <algorithm>
 #include <ctime>
 #include <fstream>
 #include <utility>
@@ -20,8 +21,6 @@
 #include <sys/stat.h>
 #include <thrift/lib/cpp/util/ThriftSerializer.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
-
-#include <algorithm>
 
 using apache::thrift::SimpleJSONSerializer;
 using std::chrono::duration_cast;
@@ -107,7 +106,6 @@ void LogsWriteHandler::onEOM() noexcept {
   LOG(INFO) << "Logs writer request from \"" << request.topology.name
             << "\" for " << request.agents.size() << " nodes";
 
-  folly::fbstring jsonResp;
   try {
     writeData(request);
   } catch (const std::exception& ex) {
@@ -122,7 +120,7 @@ void LogsWriteHandler::onEOM() noexcept {
   ResponseBuilder(downstream_)
       .status(200, "OK")
       .header("Content-Type", "application/json")
-      .body(jsonResp)
+      .body("Success")
       .sendWithEOM();
 }
 

--- a/beringei/tools/query_service/LogsWriteHandler.cpp
+++ b/beringei/tools/query_service/LogsWriteHandler.cpp
@@ -49,7 +49,7 @@ void LogsWriteHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept {
   }
 }
 
-void LogsWriteHandler::writeData(LogsWriteRequest request) {
+void LogsWriteHandler::writeData(query::LogsWriteRequest request) {
   auto startTime = (int64_t)duration_cast<milliseconds>(
                        system_clock::now().time_since_epoch())
                        .count();
@@ -90,9 +90,9 @@ void LogsWriteHandler::writeData(LogsWriteRequest request) {
 
 void LogsWriteHandler::onEOM() noexcept {
   auto body = body_->moveToFbString();
-  LogsWriteRequest request;
+  query::LogsWriteRequest request;
   try {
-    request = SimpleJSONSerializer::deserialize<LogsWriteRequest>(body);
+    request = SimpleJSONSerializer::deserialize<query::LogsWriteRequest>(body);
   } catch (const std::exception&) {
     LOG(INFO) << "Error deserializing logs_writer request";
     ResponseBuilder(downstream_)
@@ -137,6 +137,6 @@ void LogsWriteHandler::onError(ProxygenError /* unused */) noexcept {
   delete this;
 }
 
-void LogsWriteHandler::logRequest(LogsWriteRequest request) {}
+void LogsWriteHandler::logRequest(query::LogsWriteRequest request) {}
 }
 } // facebook::gorilla

--- a/beringei/tools/query_service/LogsWriteHandler.h
+++ b/beringei/tools/query_service/LogsWriteHandler.h
@@ -37,9 +37,9 @@ class LogsWriteHandler : public proxygen::RequestHandler {
   void onError(proxygen::ProxygenError err) noexcept override;
 
  private:
-  void logRequest(LogsWriteRequest request);
+  void logRequest(query::LogsWriteRequest request);
 
-  void writeData(LogsWriteRequest request);
+  void writeData(query::LogsWriteRequest request);
 
   std::unique_ptr<folly::IOBuf> body_;
 };

--- a/beringei/tools/query_service/LogsWriteHandler.h
+++ b/beringei/tools/query_service/LogsWriteHandler.h
@@ -9,26 +9,19 @@
 
 #pragma once
 
-#include "MySqlClient.h"
-
 #include <folly/Memory.h>
 #include <folly/dynamic.h>
 #include <folly/futures/Future.h>
 #include <proxygen/httpserver/RequestHandler.h>
 
-#include "beringei/client/BeringeiClient.h"
-#include "beringei/client/BeringeiConfigurationAdapterIf.h"
 #include "beringei/if/gen-cpp2/beringei_query_types_custom_protocol.h"
 
 namespace facebook {
 namespace gorilla {
 
-class WriteHandler : public proxygen::RequestHandler {
+class LogsWriteHandler : public proxygen::RequestHandler {
  public:
-  explicit WriteHandler(
-      std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter,
-      std::shared_ptr<MySqlClient> mySqlClient,
-      std::shared_ptr<BeringeiClient> beringeiClient);
+  explicit LogsWriteHandler();
 
   void onRequest(
       std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override;
@@ -44,13 +37,10 @@ class WriteHandler : public proxygen::RequestHandler {
   void onError(proxygen::ProxygenError err) noexcept override;
 
  private:
-  void logRequest(WriteRequest request);
+  void logRequest(LogsWriteRequest request);
 
-  void writeData(WriteRequest request);
+  void writeData(LogsWriteRequest request);
 
-  std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter_;
-  std::shared_ptr<MySqlClient> mySqlClient_;
-  std::shared_ptr<BeringeiClient> beringeiClient_;
   std::unique_ptr<folly::IOBuf> body_;
 };
 }

--- a/beringei/tools/query_service/MySqlClient.cpp
+++ b/beringei/tools/query_service/MySqlClient.cpp
@@ -152,11 +152,11 @@ void MySqlClient::updateNodeKeys(
     prep_stmt = con->prepareStatement(
         "INSERT IGNORE INTO `ts_key` (`node_id`, `key`) VALUES (?, ?)");
 
-    for (auto it = nodeKeys.begin(); it != nodeKeys.end(); /* empty */) {
-      LOG(INFO) << "updateNodeKeys => node_id: " << it->first
-                << " Num of keys: " << it->second.size();
-      for (const auto& nodeKey : it->second) {
-        prep_stmt->setInt(1, it->first);
+    for (const auto& keys : nodeKeys) {
+      LOG(INFO) << "updateNodeKeys => node_id: " << keys.first
+                << " Num of keys: " << keys.second.size();
+      for (const auto& nodeKey : keys.second) {
+        prep_stmt->setInt(1, keys.first);
         prep_stmt->setString(2, nodeKey);
         prep_stmt->execute();
       }

--- a/beringei/tools/query_service/MySqlClient.cpp
+++ b/beringei/tools/query_service/MySqlClient.cpp
@@ -47,7 +47,7 @@ void MySqlClient::refreshNodes() noexcept {
 
     LOG(INFO) << "refreshNodes: Number of nodes: " << res->rowsCount();
     while (res->next()) {
-      MySqlNodeData node{};
+      query::MySqlNodeData node{};
       node.id = res->getInt("id");
       node.node = res->getString("node");
       node.mac = res->getString("mac");
@@ -121,7 +121,7 @@ void MySqlClient::refreshEventCategories() noexcept {
 }
 
 void MySqlClient::addNodes(
-    std::unordered_map<std::string, MySqlNodeData> newNodes) noexcept {
+    std::unordered_map<std::string, query::MySqlNodeData> newNodes) noexcept {
   if (!newNodes.size()) {
     return;
   }
@@ -261,7 +261,7 @@ folly::Optional<int64_t> MySqlClient::getEventCategoryId(
   return folly::none;
 }
 
-void MySqlClient::addEvents(std::vector<MySqlEventData> events) noexcept {
+void MySqlClient::addEvents(std::vector<query::MySqlEventData> events) noexcept {
   if (!events.size()) {
     return;
   }
@@ -288,7 +288,7 @@ void MySqlClient::addEvents(std::vector<MySqlEventData> events) noexcept {
   }
 }
 
-void MySqlClient::addAlert(MySqlAlertData alert) noexcept {
+void MySqlClient::addAlert(query::MySqlAlertData alert) noexcept {
   try {
     std::string query =
         "INSERT INTO `alerts` (`node_id`, `timestamp`, `alert_id`, `alert_regex`, `alert_threshold`, `alert_comparator`, `alert_level`, `trigger_key`, `trigger_value`) VALUES (?, FROM_UNIXTIME(?), ?, ?, ?, ?, ?, ?, ?)";

--- a/beringei/tools/query_service/MySqlClient.cpp
+++ b/beringei/tools/query_service/MySqlClient.cpp
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "MySqlClient.h"
+
+#include <utility>
+
+#include <folly/DynamicConverter.h>
+#include <folly/io/IOBuf.h>
+#include <thrift/lib/cpp/util/ThriftSerializer.h>
+#include <thrift/lib/cpp2/protocol/Serializer.h>
+
+#include "mysql_connection.h"
+#include "mysql_driver.h"
+
+#include <cppconn/driver.h>
+#include <cppconn/exception.h>
+#include <cppconn/prepared_statement.h>
+#include <cppconn/resultset.h>
+#include <cppconn/statement.h>
+
+DEFINE_string(mysql_url, "localhost", "mysql host");
+DEFINE_string(mysql_user, "root", "mysql user");
+DEFINE_string(mysql_pass, "", "mysql passward");
+DEFINE_string(mysql_database, "cxl", "mysql database");
+
+namespace facebook {
+namespace gorilla {
+
+MySqlClient::MySqlClient() {
+  refreshNodes();
+  refreshNodeKeys();
+}
+
+void MySqlClient::refreshNodes() noexcept {
+  try {
+    sql::Driver* driver = sql::mysql::get_driver_instance();
+    /* Using the Driver to create a connection */
+    std::unique_ptr<sql::Connection> con(
+        driver->connect(FLAGS_mysql_url, FLAGS_mysql_user, FLAGS_mysql_pass));
+    con->setSchema(FLAGS_mysql_database);
+
+    std::unique_ptr<sql::Statement> stmt(con->createStatement());
+    std::unique_ptr<sql::ResultSet> res(
+        stmt->executeQuery("SELECT * FROM `nodes`"));
+
+    LOG(INFO) << "refreshNodes: Number of nodes: " << res->rowsCount();
+    while (res->next()) {
+      MySqlNodeData node{};
+      node.id = res->getInt("id");
+      node.node = res->getString("node");
+      node.mac = res->getString("mac");
+      node.network = res->getString("network");
+      node.site = res->getString("site");
+
+      std::transform(
+          node.mac.begin(), node.mac.end(), node.mac.begin(), ::tolower);
+      macAddrToNode_[node.mac] = node;
+    }
+  } catch (sql::SQLException& e) {
+    LOG(ERROR) << "ERR: " << e.what();
+    LOG(ERROR) << " (MySQL error code: " << e.getErrorCode();
+  }
+}
+
+void MySqlClient::refreshNodeKeys() noexcept {
+  try {
+    sql::Driver* driver = sql::mysql::get_driver_instance();
+    /* Using the Driver to create a connection */
+    std::unique_ptr<sql::Connection> con(
+        driver->connect(FLAGS_mysql_url, FLAGS_mysql_user, FLAGS_mysql_pass));
+    con->setSchema(FLAGS_mysql_database);
+
+    std::unique_ptr<sql::Statement> stmt(con->createStatement());
+    std::unique_ptr<sql::ResultSet> res(
+        stmt->executeQuery("SELECT `id`, `node_id`, `key` FROM `ts_key`"));
+
+    LOG(INFO) << "refreshNodeKeys: Number of keys: " << res->rowsCount();
+    while (res->next()) {
+      int64_t keyId = res->getInt("id");
+      int64_t nodeId = res->getInt("node_id");
+      std::string keyName = res->getString("key");
+
+      std::transform(
+          keyName.begin(), keyName.end(), keyName.begin(), ::tolower);
+      auto itNode = nodeKeyIds_.find(nodeId);
+      if (nodeKeyIds_.find(nodeId) == nodeKeyIds_.end()) {
+        nodeKeyIds_[nodeId] = {};
+      }
+      nodeKeyIds_[nodeId][keyName] = keyId;
+    }
+  } catch (sql::SQLException& e) {
+    LOG(ERROR) << "ERR: " << e.what();
+    LOG(ERROR) << " (MySQL error code: " << e.getErrorCode();
+  }
+}
+
+void MySqlClient::addNodes(
+    std::unordered_map<std::string, MySqlNodeData> newNodes) noexcept {
+  if (!newNodes.size()) {
+    return;
+  }
+  try {
+    sql::Driver* driver = sql::mysql::get_driver_instance();
+    /* Using the Driver to create a connection */
+    std::unique_ptr<sql::Connection> con(
+        driver->connect(FLAGS_mysql_url, FLAGS_mysql_user, FLAGS_mysql_pass));
+    con->setSchema(FLAGS_mysql_database);
+
+    std::unique_ptr<sql::PreparedStatement> prep_stmt(
+        con->prepareStatement("INSERT IGNORE INTO `nodes` (`mac`, `node`, "
+                              "`site`, `network`) VALUES (?, ?, ?, ?)"));
+
+    for (const auto& node : newNodes) {
+      prep_stmt->setString(1, node.second.mac);
+      prep_stmt->setString(2, node.second.node);
+      prep_stmt->setString(3, node.second.site);
+      prep_stmt->setString(4, node.second.network);
+      prep_stmt->execute();
+      LOG(INFO) << "addNode => mac: " << node.second.mac
+                << " Network: " << node.second.network;
+    }
+  } catch (sql::SQLException& e) {
+    LOG(ERROR) << "ERR: " << e.what();
+    LOG(ERROR) << " (MySQL error code: " << e.getErrorCode();
+  }
+
+  refreshNodes();
+}
+
+void MySqlClient::updateNodeKeys(
+    std::unordered_map<int64_t, std::unordered_set<std::string>>
+        nodeKeys) noexcept {
+  if (!nodeKeys.size()) {
+    return;
+  }
+  LOG(INFO) << "updateNodeKeys for " << nodeKeys.size() << " nodes";
+  try {
+    sql::Driver* driver = sql::mysql::get_driver_instance();
+    /* Using the Driver to create a connection */
+    std::unique_ptr<sql::Connection> con(
+        driver->connect(FLAGS_mysql_url, FLAGS_mysql_user, FLAGS_mysql_pass));
+    con->setSchema(FLAGS_mysql_database);
+
+    sql::PreparedStatement* prep_stmt;
+    prep_stmt = con->prepareStatement(
+        "INSERT IGNORE INTO `ts_key` (`node_id`, `key`) VALUES (?, ?)");
+
+    for (auto it = nodeKeys.begin(); it != nodeKeys.end(); /* empty */) {
+      LOG(INFO) << "updateNodeKeys => node_id: " << it->first
+                << " Num of keys: " << it->second.size();
+      for (const auto& nodeKey : it->second) {
+        prep_stmt->setInt(1, it->first);
+        prep_stmt->setString(2, nodeKey);
+        prep_stmt->execute();
+      }
+    }
+  } catch (sql::SQLException& e) {
+    LOG(ERROR) << "ERR: " << e.what();
+    LOG(ERROR) << " (MySQL error code: " << e.getErrorCode();
+  }
+
+  refreshNodeKeys();
+}
+
+folly::Optional<int64_t> MySqlClient::getNodeId(
+    const std::string& macAddr) const {
+  std::string macAddrLower = macAddr;
+  std::transform(
+      macAddrLower.begin(),
+      macAddrLower.end(),
+      macAddrLower.begin(),
+      ::tolower);
+  auto it = macAddrToNode_.find(macAddrLower);
+  if (it != macAddrToNode_.end()) {
+    return (it->second.id);
+  }
+  return folly::none;
+}
+
+folly::Optional<int64_t> MySqlClient::getKeyId(
+    const int64_t nodeId,
+    const std::string& keyName) const {
+  std::string keyNameLower = keyName;
+  std::transform(
+      keyNameLower.begin(),
+      keyNameLower.end(),
+      keyNameLower.begin(),
+      ::tolower);
+
+  auto itNode = nodeKeyIds_.find(nodeId);
+  if (itNode != nodeKeyIds_.end()) {
+    auto itKey = itNode->second.find(keyNameLower);
+    if (itKey != itNode->second.end()) {
+      return (itKey->second);
+    }
+  }
+  return folly::none;
+}
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/MySqlClient.cpp
+++ b/beringei/tools/query_service/MySqlClient.cpp
@@ -293,19 +293,14 @@ void MySqlClient::addEvents(std::vector<MySqlEventData> events) noexcept {
   try {
     std::string query =
         "INSERT INTO `events` (`sample`, `timestamp`, `category_id`) VALUES ";
+    std::vector<std::string> vec(events.size(), "(?, ?, ?)");
+    query += folly::join(",", vec);
     int64_t index = 0;
-    for (const auto& event : events) {
-      if (index++ == 0) {
-        query += "(?, ?, ?)";
-      } else {
-        query += ",(?, ?, ?)";
-      }
-    }
+
     std::unique_ptr<sql::PreparedStatement> prep_stmt(
         connection_->prepareStatement(query));
 
     LOG(INFO) << "addEvents: " << events.size();
-    index = 0;
     for (const auto& event : events) {
       prep_stmt->setString(++index, event.sample);
       prep_stmt->setDateTime(++index, event.timestamp);

--- a/beringei/tools/query_service/MySqlClient.h
+++ b/beringei/tools/query_service/MySqlClient.h
@@ -14,6 +14,14 @@
 #include <folly/futures/Future.h>
 
 #include "beringei/if/gen-cpp2/beringei_query_types_custom_protocol.h"
+#include "mysql_connection.h"
+#include "mysql_driver.h"
+
+#include <cppconn/driver.h>
+#include <cppconn/exception.h>
+#include <cppconn/prepared_statement.h>
+#include <cppconn/resultset.h>
+#include <cppconn/statement.h>
 
 namespace facebook {
 namespace gorilla {
@@ -42,6 +50,8 @@ class MySqlClient {
       const std::string& keyName) const;
 
  private:
+  sql::Driver* driver_;
+  std::unique_ptr<sql::Connection> connection_;
   MacToNodeMap macAddrToNode_{};
   NodeKeyMap nodeKeyIds_{};
 };

--- a/beringei/tools/query_service/MySqlClient.h
+++ b/beringei/tools/query_service/MySqlClient.h
@@ -29,31 +29,48 @@ namespace gorilla {
 typedef std::unordered_map<std::string, MySqlNodeData> MacToNodeMap;
 typedef std::unordered_map<int64_t, std::unordered_map<std::string, int64_t>>
     NodeKeyMap;
+typedef std::unordered_map<int64_t, std::unordered_map<std::string, int64_t>>
+    NodeCategoryMap;
 
 class MySqlClient {
  public:
   MySqlClient();
-  void addNodes(
-      std::unordered_map<std::string, MySqlNodeData> newNodes) noexcept;
 
   void refreshNodes() noexcept;
 
-  void updateNodeKeys(
-      std::unordered_map<int64_t, std::unordered_set<std::string>>
-          nodeKeys) noexcept;
+  void refreshStatKeys() noexcept;
 
-  void refreshNodeKeys() noexcept;
+  void refreshEventCategories() noexcept;
+
+  void addNodes(
+      std::unordered_map<std::string, MySqlNodeData> newNodes) noexcept;
+
+  void addStatKeys(std::unordered_map<int64_t, std::unordered_set<std::string>>
+                       nodeKeys) noexcept;
+
+  void addEventCategories(
+      std::unordered_map<int64_t, std::unordered_set<std::string>>
+          eventCategories) noexcept;
 
   folly::Optional<int64_t> getNodeId(const std::string& macAddr) const;
+
   folly::Optional<int64_t> getKeyId(
       const int64_t nodeId,
       const std::string& keyName) const;
+
+  folly::Optional<int64_t> getEventCategoryId(
+      const int64_t nodeId,
+      const std::string& category) const;
+
+  void addEvents(std::vector<MySqlEventData> events) noexcept;
+  void addAlert(MySqlAlertData alert) noexcept;
 
  private:
   sql::Driver* driver_;
   std::unique_ptr<sql::Connection> connection_;
   MacToNodeMap macAddrToNode_{};
   NodeKeyMap nodeKeyIds_{};
+  NodeCategoryMap nodeCategoryIds_{};
 };
 }
 } // facebook::gorilla

--- a/beringei/tools/query_service/MySqlClient.h
+++ b/beringei/tools/query_service/MySqlClient.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include <folly/Memory.h>
+#include <folly/dynamic.h>
+#include <folly/futures/Future.h>
+
+#include "beringei/if/gen-cpp2/beringei_query_types_custom_protocol.h"
+
+namespace facebook {
+namespace gorilla {
+
+typedef std::unordered_map<std::string, MySqlNodeData> MacToNodeMap;
+typedef std::unordered_map<int64_t, std::unordered_map<std::string, int64_t>>
+    NodeKeyMap;
+
+class MySqlClient {
+ public:
+  MySqlClient();
+  void addNodes(
+      std::unordered_map<std::string, MySqlNodeData> newNodes) noexcept;
+
+  void refreshNodes() noexcept;
+
+  void updateNodeKeys(
+      std::unordered_map<int64_t, std::unordered_set<std::string>>
+          nodeKeys) noexcept;
+
+  void refreshNodeKeys() noexcept;
+
+  folly::Optional<int64_t> getNodeId(const std::string& macAddr) const;
+  folly::Optional<int64_t> getKeyId(
+      const int64_t nodeId,
+      const std::string& keyName) const;
+
+ private:
+  MacToNodeMap macAddrToNode_{};
+  NodeKeyMap nodeKeyIds_{};
+};
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/MySqlClient.h
+++ b/beringei/tools/query_service/MySqlClient.h
@@ -26,7 +26,7 @@
 namespace facebook {
 namespace gorilla {
 
-typedef std::unordered_map<std::string, MySqlNodeData> MacToNodeMap;
+typedef std::unordered_map<std::string, query::MySqlNodeData> MacToNodeMap;
 typedef std::unordered_map<int64_t, std::unordered_map<std::string, int64_t>>
     NodeKeyMap;
 typedef std::unordered_map<int64_t, std::unordered_map<std::string, int64_t>>
@@ -43,7 +43,7 @@ class MySqlClient {
   void refreshEventCategories() noexcept;
 
   void addNodes(
-      std::unordered_map<std::string, MySqlNodeData> newNodes) noexcept;
+      std::unordered_map<std::string, query::MySqlNodeData> newNodes) noexcept;
 
   void addStatKeys(std::unordered_map<int64_t, std::unordered_set<std::string>>
                        nodeKeys) noexcept;
@@ -62,8 +62,8 @@ class MySqlClient {
       const int64_t nodeId,
       const std::string& category) const;
 
-  void addEvents(std::vector<MySqlEventData> events) noexcept;
-  void addAlert(MySqlAlertData alert) noexcept;
+  void addEvents(std::vector<query::MySqlEventData> events) noexcept;
+  void addAlert(query::MySqlAlertData alert) noexcept;
 
  private:
   sql::Driver* driver_;

--- a/beringei/tools/query_service/NotFoundHandler.cpp
+++ b/beringei/tools/query_service/NotFoundHandler.cpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "NotFoundHandler.h"
+
+#include <proxygen/httpserver/ResponseBuilder.h>
+
+using namespace proxygen;
+
+namespace facebook {
+namespace gorilla {
+
+void NotFoundHandler::onRequest(
+    std::unique_ptr<HTTPMessage> /* unused */) noexcept {
+  // nothing to do
+}
+
+void NotFoundHandler::onBody(
+    std::unique_ptr<folly::IOBuf> /* unused */) noexcept {
+  // nothing to do
+}
+
+void NotFoundHandler::onEOM() noexcept {
+  // return not found
+  ResponseBuilder(downstream_).status(404, "NOT FOUND").sendWithEOM();
+}
+
+void NotFoundHandler::onUpgrade(UpgradeProtocol /* unused */) noexcept {
+  // handler doesn't support upgrades
+}
+
+void NotFoundHandler::requestComplete() noexcept {
+  // In QueryServiceFactory, we created this handler using new.
+  // Proxygen does not delete the handler.
+  delete this;
+}
+
+void NotFoundHandler::onError(ProxygenError /* unused */) noexcept {
+  // In QueryServiceFactory, we created this handler using new.
+  // Proxygen does not delete the handler.
+  delete this;
+}
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/NotFoundHandler.h
+++ b/beringei/tools/query_service/NotFoundHandler.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include <folly/Memory.h>
+#include <proxygen/httpserver/RequestHandler.h>
+
+namespace facebook {
+namespace gorilla {
+
+// Handler that returns 404 for apis that are not implemented
+class NotFoundHandler : public proxygen::RequestHandler {
+ public:
+  void onRequest(
+      std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override;
+
+  void onBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
+
+  void onEOM() noexcept override;
+
+  void onUpgrade(proxygen::UpgradeProtocol proto) noexcept override;
+
+  void requestComplete() noexcept override;
+
+  void onError(proxygen::ProxygenError err) noexcept override;
+};
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/QueryHandler.cpp
+++ b/beringei/tools/query_service/QueryHandler.cpp
@@ -1,0 +1,472 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "QueryHandler.h"
+
+#include <utility>
+
+#include <folly/DynamicConverter.h>
+#include <folly/io/IOBuf.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include <thrift/lib/cpp/util/ThriftSerializer.h>
+#include <thrift/lib/cpp2/protocol/Serializer.h>
+
+using apache::thrift::SimpleJSONSerializer;
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::system_clock;
+using namespace proxygen;
+
+namespace facebook {
+namespace gorilla {
+
+const int MAX_COLUMNS = 7;
+const int MAX_DATA_POINTS = 60;
+
+QueryHandler::QueryHandler(
+    std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter)
+    : RequestHandler(), configurationAdapter_(configurationAdapter) {}
+
+void QueryHandler::onRequest(
+    std::unique_ptr<HTTPMessage> /* unused */) noexcept {
+  // nothing to do
+}
+
+void QueryHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept {
+  if (body_) {
+    body_->prependChain(move(body));
+  } else {
+    body_ = move(body);
+  }
+}
+
+void QueryHandler::onEOM() noexcept {
+  auto body = body_->moveToFbString();
+  auto request = SimpleJSONSerializer::deserialize<QueryRequest>(body);
+  logRequest(request);
+  columnNames_.clear();
+  timeSeries_.clear();
+  aggSeries_.clear();
+  query_ = request.queries[0];
+  LOG(INFO) << "Request for " << query_.key_ids.size() << " key ids of "
+            << query_.agg_type << " aggregation, for " << query_.min_ago
+            << " minutes ago.";
+ 
+  folly::fbstring jsonResp = handleQuery();
+  ResponseBuilder(downstream_)
+      .status(200, "OK")
+      .header("Content-Type", "application/json")
+      .body(jsonResp)
+    .sendWithEOM();
+}
+
+void QueryHandler::onUpgrade(UpgradeProtocol /* unused */) noexcept { }
+
+void QueryHandler::requestComplete() noexcept {
+  delete this;
+}
+
+void QueryHandler::onError(ProxygenError /* unused */) noexcept {
+  LOG(ERROR) << "Proxygen reported error";
+  // In QueryServiceFactory, we created this handler using new.
+  // Proxygen does not delete the handler.
+  delete this;
+}
+
+void QueryHandler::logRequest(QueryRequest request) { }
+
+void QueryHandler::columnNames() {
+  // set column names
+  if (query_.agg_type == "top" ||
+      query_.agg_type == "bottom") {
+    // top, bottom, none
+    std::unordered_set<std::string> keyNames;
+    std::unordered_set<std::string> linkNames;
+    std::unordered_set<std::string> displayNames;
+    for (const auto& keyData : query_.data) {
+      keyNames.insert(keyData.key);
+      linkNames.insert(keyData.linkName);
+      displayNames.insert(keyData.displayName);
+    }
+    for (const auto& keyData : query_.data) {
+      std::string columnName = keyData.node;
+      if (keyData.linkName.length()) {
+        columnName = keyData.linkName;
+      } else if (keyData.displayName.length() && displayNames.size() > 1) {
+        columnName = keyData.displayName;
+      } else if (keyNames.size() > 1) {
+        columnName = keyData.key;
+      } else if (keyData.nodeName.length()) {
+        columnName = keyData.nodeName;
+      }
+      std::replace(columnName.begin(), columnName.end(), '.', ' ');
+      columnNames_.push_back(columnName);
+    }
+  }
+}
+
+/**
+ * Common metrics
+ *
+ * Uptime/availability
+ * Iterate over all data points
+ */
+folly::fbstring QueryHandler::eventHandler(int dataPointIncrementMs) {
+  int64_t timeBucketCount = (endTime_ - startTime_) / 30;
+  int keyCount = beringeiTimeSeries_.size();
+  // count is a special aggregation that will be missed due to default values
+  int timeSeriesCounts[timeBucketCount]{};
+  // pre-allocate the array size
+  double timeSeries[keyCount][timeBucketCount]{};
+  int keyIndex = 0;
+  for (const auto& keyTimeSeries : beringeiTimeSeries_) {
+    const std::string& keyName = keyTimeSeries.first.key;
+    for (const auto& timePair : keyTimeSeries.second) {
+      int timeBucketId = (timePair.unixTime - startTime_) / 30;
+      timeSeries[keyIndex][timeBucketId] = timePair.value;
+    }
+    keyIndex++;
+  }
+  int expectedDataPoints = 30 * (1000 / (double)dataPointIncrementMs);
+  // iterate over all expected data points
+  folly::dynamic linkMap = folly::dynamic::object;
+  for (int keyIndex = 0; keyIndex < keyCount; keyIndex++) {
+    int missingCounter = 0;
+    int upPoints = 0;
+    double partialSeconds = 0;
+    int startOnlineIndex = -1;
+    folly::dynamic onlineEvents = folly::dynamic::array;
+    for (int timeIndex = 0; timeIndex < timeBucketCount; timeIndex++) {
+      double timeVal = timeSeries[keyIndex][timeIndex];
+      if (timeVal == 0) {
+        missingCounter++;
+        // missing data
+      } else if (timeVal >= expectedDataPoints) {
+        // whole interval is good
+        if (missingCounter) {
+          // determine how many gaps to fill
+          double partialIntervalSec = timeVal / expectedDataPoints;
+          double completeIntervals = partialIntervalSec / 30;
+          if (completeIntervals >= missingCounter) {
+            // we covered up all missing data points
+            upPoints += missingCounter;
+            LOG(INFO) << "[" << timeIndex << "] Filled all " << missingCounter << " missed data buckets";
+            // online events
+            if (startOnlineIndex == -1) {
+              startOnlineIndex = timeIndex - missingCounter;
+            }
+            LOG(INFO) << "[" << timeIndex << "] Marked starting index of uptime: " << startOnlineIndex;
+          } else {
+            // fill partial interval
+            int wholeIntervals = (int)completeIntervals;
+            upPoints+= wholeIntervals;
+            double remainIntervalSec = partialIntervalSec - (wholeIntervals * 30);
+            LOG(INFO) << "[" << timeIndex << "] Filled partial missing data buckets. Missing intervals: "
+                      << missingCounter << ", covered intervals: " << completeIntervals
+                      << " (" << wholeIntervals << "), partial seconds: " << remainIntervalSec;
+            partialSeconds += remainIntervalSec;
+            // events, ignore partial intervals
+            if (startOnlineIndex == -1) {
+              startOnlineIndex = timeIndex - wholeIntervals;
+            }
+          }
+          missingCounter = 0;
+        }
+        if (startOnlineIndex == -1) {
+          LOG(INFO) << "Marking start index: " << timeIndex;
+          startOnlineIndex = timeIndex;
+        }
+        upPoints++;
+      } else {
+        // part of interval is good, calculate how much of it to mark
+        double partialIntervalSec = timeVal / expectedDataPoints;
+        partialSeconds += partialIntervalSec;
+        LOG(INFO) << "[" << timeIndex << "] Some part of interval is up, about " << partialIntervalSec;
+        // events
+        if (startOnlineIndex >= 0) {
+          // partial interval, mark this interval as down
+          LOG(INFO) << "[" << timeIndex << "] Partially online interval, marking offline. We were online for: "
+                    << (timeIndex - startOnlineIndex) << " intervals, missing counter: " << missingCounter;
+          // push event
+          onlineEvents.push_back(folly::dynamic::object
+            ("startTime", (startTime_ + (startOnlineIndex * 30)))
+            ("endTime", (startTime_ + ((timeIndex - missingCounter) * 30)))
+            ("title", ("Online Partial " + std::to_string(startOnlineIndex) +
+                       " <-> " + std::to_string(timeIndex - missingCounter))));
+          startOnlineIndex = -1;
+        }
+        // reset missing counter, which only tracks whole intervals offline
+        missingCounter = 0;
+      }
+      // finalize events
+      if ((timeIndex + 1) == timeBucketCount && startOnlineIndex >= 0) {
+        LOG(INFO) << "Start online index set, push event from start: "
+                  << startOnlineIndex << " to: " << timeIndex;
+        onlineEvents.push_back(folly::dynamic::object
+          ("startTime", (startTime_ + (startOnlineIndex * 30)))
+          ("endTime", (endTime_))
+          ("title", ("Online " + std::to_string(startOnlineIndex) +
+                     " <-> " + std::to_string(timeIndex))));
+      }
+    }
+    // seconds of uptime / seconds in period
+    double uptimePerc = 0;
+    if (upPoints > 0 || partialSeconds > 0) {
+      uptimePerc = (upPoints * 30 + partialSeconds) / (timeBucketCount * 30) * 100.0;
+    }
+    auto& linkName = query_.data[keyIndex].linkName;
+    LOG(INFO) << "Key ID: " << query_.data[keyIndex].key
+              << ", Link name: " << linkName
+              << ", Expected count: " << timeBucketCount
+              << ", up count: " << upPoints
+              << ", partial seconds: " << partialSeconds
+              << ", uptime: " << uptimePerc << "%";
+    linkMap[linkName] = folly::dynamic::object;
+    linkMap[linkName]["alive"] = uptimePerc;
+    linkMap[linkName]["events"] = onlineEvents;
+  }
+      
+  folly::dynamic response = folly::dynamic::object;
+  response["links"] = linkMap;
+  response["start"] = startTime_ * 1000;
+  response["end"] = endTime_ * 1000;
+  return folly::toJson(response);
+
+}
+
+folly::fbstring QueryHandler::transform() {
+  // time align all data
+  int64_t timeBucketCount = (endTime_ - startTime_) / 30;
+  int keyCount = beringeiTimeSeries_.size();
+  // count is a special aggregation that will be missed due to default values
+  int timeSeriesCounts[timeBucketCount]{};
+  // pre-allocate the array size
+  double timeSeries[keyCount][timeBucketCount]{};
+  int keyIndex = 0;
+  for (const auto& keyTimeSeries : beringeiTimeSeries_) {
+    const std::string& keyName = keyTimeSeries.first.key;
+    for (const auto& timePair : keyTimeSeries.second) {
+      int timeBucketId = (timePair.unixTime - startTime_) / 30;
+      timeSeries[keyIndex][timeBucketId] = timePair.value;
+      timeSeriesCounts[timeBucketId]++;
+    }
+    keyIndex++;
+  }
+  int dataPointAggCount = 1;
+  if (timeBucketCount > MAX_DATA_POINTS) {
+    dataPointAggCount = std::ceil((double)timeBucketCount / MAX_DATA_POINTS);
+  }
+  int condensedBucketCount = timeBucketCount / dataPointAggCount;
+  // allocate condensed time series, sum series (by key) for later
+  // sorting, and sum of time bucket
+  double cTimeSeries[keyCount][condensedBucketCount]{};
+  double sumSeries[keyCount]{};
+  double sumTimeBucket[condensedBucketCount]{};
+  for (int i = 0; i < keyCount; i++) {
+    int timeBucketId = 0;
+    int startBucketId = 0;
+    int endBucketId = 0 + dataPointAggCount;
+    while (startBucketId < timeBucketCount) {
+      // fetch all data points we need to aggregate
+      if (endBucketId >= timeBucketCount) {
+        endBucketId = timeBucketCount - 1;
+      }
+      // aggregations
+      double sum = std::accumulate(&timeSeries[i][startBucketId],
+                                   &timeSeries[i][endBucketId + 1],
+                                   0.0);
+      double avg = sum / (double)(endBucketId - startBucketId + 1);
+      auto minMax = std::minmax_element(&timeSeries[i][startBucketId],
+                                        &timeSeries[i][endBucketId + 1]);
+      double min = *minMax.first;
+      double max = *minMax.second;
+      sumTimeBucket[timeBucketId] += avg;
+      if (query_.agg_type == "avg") {
+        // the time aggregated bucket for this key
+        if (i == 0) {
+          aggSeries_["min"].push_back(min);
+          aggSeries_["max"].push_back(max);
+        } else {
+          aggSeries_["min"][timeBucketId] =
+            std::min(aggSeries_["min"][timeBucketId], min);
+          aggSeries_["max"][timeBucketId] =
+            std::max(aggSeries_["max"][timeBucketId], max);
+        }
+      } else if (query_.agg_type == "count") {
+        double countSum = std::accumulate(&timeSeriesCounts[startBucketId],
+                                          &timeSeriesCounts[endBucketId + 1],
+                                          0);
+        double countAvg = countSum / (double)(endBucketId - startBucketId + 1);
+        aggSeries_[query_.agg_type].push_back(countAvg);
+      } else if (query_.agg_type == "event") {
+        // event aggregation
+        // I0524 19:17:35.861244 23268 QueryHandler.cpp:190] Bucket[0][2877] = 964
+        // I0524 19:17:35.861249 23268 QueryHandler.cpp:190] Bucket[0][2878] = 2136
+        // I0524 19:17:35.861253 23268 QueryHandler.cpp:190] Bucket[0][2879] = 3308
+        for (int e = startBucketId; e <= endBucketId; e++) {
+          LOG(INFO) << "Bucket[" << i << "][" << e << "] = " << timeSeries[i][e];
+        }
+      } else {
+        // no aggregation
+        cTimeSeries[i][timeBucketId] = avg;
+        if (keyCount > MAX_COLUMNS) {
+          sumSeries[i] += sum;
+        }
+      }
+      // set next bucket
+      startBucketId += dataPointAggCount;
+      endBucketId += dataPointAggCount;
+      timeBucketId++;
+    }
+  }
+  // now we have time aggregated data
+  // sort by avg value across time series if needed
+  folly::dynamic datapoints = folly::dynamic::array();
+  for (int i = 0; i < (timeBucketCount / dataPointAggCount); i++) {
+    datapoints.push_back(folly::dynamic::array(
+      (startTime_ + (i * dataPointAggCount * 30)) * 1000));
+  }
+  folly::dynamic columns = folly::dynamic::array();
+  columns.push_back("time");
+  if (query_.agg_type == "bottom" ||
+      query_.agg_type == "top") {
+    if (keyCount > MAX_COLUMNS) {
+      // sort data
+      std::vector<std::pair<int, double>> keySums;
+      for (int i = 0; i < keyCount; i++) {
+        keySums.push_back(std::make_pair(i, sumSeries[i]));
+      }
+      auto sortLess = [](auto& lhs, auto& rhs) {return lhs.second < rhs.second;};
+      auto sortGreater = [](auto& lhs, auto& rhs) {return lhs.second > rhs.second;};
+      if (query_.agg_type == "bottom") {
+        std::sort(keySums.begin(), keySums.end(), sortLess);
+      } else {
+        std::sort(keySums.begin(), keySums.end(), sortGreater);
+      }
+      keySums.resize(MAX_COLUMNS);
+      for (const auto& kv : keySums) {
+        columns.push_back(columnNames_[kv.first]);
+        // loop over time series
+        for (int i = 0; i < (timeBucketCount / dataPointAggCount); i++) {
+          datapoints[i].push_back(timeSeries[kv.first][i]);
+        }
+      }
+    } else {
+      // agg series
+      for (int i = 0; i < keyCount; i++) {
+        columns.push_back(columnNames_[i]);
+        // loop over time series
+        for (int e = 0; e < condensedBucketCount; e++) {
+          datapoints[e].push_back(cTimeSeries[i][e]);
+        }
+      }
+    }
+  } else if (query_.agg_type == "sum") {
+    columns.push_back(query_.agg_type);
+    for (int i = 0; i < condensedBucketCount; i++) {
+      datapoints[i].push_back(sumTimeBucket[i]);
+    }
+  } else if (query_.agg_type == "count") {
+    for (const auto& aggSerie : aggSeries_) {
+      columns.push_back(aggSerie.first);
+      for (int i = 0; i < condensedBucketCount; i++) {
+        datapoints[i].push_back(aggSerie.second[i]);
+      }
+    }
+  } else if (query_.agg_type == "avg") {
+    // show agg series
+    for (const auto& aggSerie : aggSeries_) {
+      columns.push_back(aggSerie.first);
+      for (int i = 0; i < condensedBucketCount; i++) {
+        datapoints[i].push_back(aggSerie.second[i]);
+      }
+    }
+    columns.push_back("avg");
+    for (int i = 0; i < condensedBucketCount; i++) {
+      datapoints[i].push_back(sumTimeBucket[i] / keyCount);
+    }
+  }
+  folly::dynamic response = folly::dynamic::object;
+  response["name"] = "id";
+  response["columns"] = columns;
+  response["points"] = datapoints;
+  return "[" + folly::toJson(response) + "]";
+}
+
+folly::fbstring QueryHandler::handleQuery() {
+  auto startTime = (int64_t)duration_cast<milliseconds>(
+        system_clock::now().time_since_epoch()).count();
+  folly::Promise<TimeSeries> p;
+  auto f = p.getFuture();
+  folly::EventBase eb;
+  eb.runInLoop([this, p = std::move(p)] () mutable {
+    BeringeiClient client(
+        configurationAdapter_, 1, BeringeiClient::kNoWriterThreads);
+    int numShards = client.getNumShards();
+    auto beringeiRequest = createBeringeiRequest(query_, numShards);
+    client.get(beringeiRequest, beringeiTimeSeries_);
+  });
+  std::thread tEb([&eb]() { eb.loop(); });
+  tEb.join();
+  auto fetchTime = (int64_t)duration_cast<milliseconds>(
+        system_clock::now().time_since_epoch()).count();
+  columnNames();
+  auto columnNamesTime = (int64_t)duration_cast<milliseconds>(
+        system_clock::now().time_since_epoch()).count();
+  folly::fbstring results{};
+  if (query_.type == "event") {
+    results = eventHandler(26 /* ms for heartbeats */);
+  } else {
+    results = transform();
+  }
+  auto endTime = (int64_t)duration_cast<milliseconds>(
+        system_clock::now().time_since_epoch()).count();
+  // TODO - add fetch
+  LOG(INFO) << "Query completed. " 
+            << "Fetch: " << (fetchTime - startTime) << "ms, "
+            << "Column names: " << (columnNamesTime - fetchTime) << "ms, "
+            << "Transform: " << (endTime - columnNamesTime) << "ms, "
+            << "Total: " << (endTime - startTime) << "ms.";
+  return results;
+}
+
+int QueryHandler::getShardId(const std::string& key, const int numShards) {
+  std::hash<std::string> hash;
+  size_t hashValue = hash(key);
+
+  if (numShards != 0) {
+    return hashValue % numShards;
+  } else {
+    return hashValue;
+  }
+}
+
+GetDataRequest QueryHandler::createBeringeiRequest(
+    const Query& request,
+    const int numShards) {
+  // TODO - absolute time
+  startTime_ = std::time(nullptr) - (request.min_ago * 60);
+  endTime_ = std::time(nullptr);
+  GetDataRequest beringeiRequest;
+
+  beringeiRequest.begin = startTime_;
+  beringeiRequest.end = endTime_;
+
+  for (const auto& keyId : request.key_ids) {
+    Key beringeiKey;
+    beringeiKey.key = std::to_string(keyId);
+    // everything is shard 0 on the writer side
+    beringeiKey.shardId = 0;
+    beringeiRequest.keys.push_back(beringeiKey);
+  }
+
+  return beringeiRequest;
+}
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/QueryHandler.cpp
+++ b/beringei/tools/query_service/QueryHandler.cpp
@@ -51,9 +51,9 @@ void QueryHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept {
 
 void QueryHandler::onEOM() noexcept {
   auto body = body_->moveToFbString();
-  QueryRequest request;
+  query::QueryRequest request;
   try {
-    request = SimpleJSONSerializer::deserialize<QueryRequest>(body);
+    request = SimpleJSONSerializer::deserialize<query::QueryRequest>(body);
   } catch (const std::exception&) {
     LOG(INFO) << "Error deserializing QueryRequest";
     ResponseBuilder(downstream_)
@@ -114,7 +114,7 @@ void QueryHandler::onError(ProxygenError /* unused */) noexcept {
   delete this;
 }
 
-void QueryHandler::logRequest(QueryRequest request) { }
+void QueryHandler::logRequest(query::QueryRequest request) { }
 
 void QueryHandler::columnNames() {
   // set column names
@@ -536,7 +536,7 @@ int QueryHandler::getShardId(const std::string& key, const int numShards) {
 }
 
 void QueryHandler::validateQuery(
-    const Query& request) {
+    const query::Query& request) {
   if (request.__isset.start_ts &&
       request.__isset.end_ts) {
     // TODO - sanity check time
@@ -559,7 +559,7 @@ void QueryHandler::validateQuery(
 }
 
 GetDataRequest QueryHandler::createBeringeiRequest(
-    const Query& request,
+    const query::Query& request,
     const int numShards) {
   GetDataRequest beringeiRequest;
 

--- a/beringei/tools/query_service/QueryHandler.cpp
+++ b/beringei/tools/query_service/QueryHandler.cpp
@@ -516,6 +516,9 @@ GetDataRequest QueryHandler::createBeringeiRequest(
     LOG(INFO) << "Start/end time set, use that";
     startTime_ = std::ceil(request.start_ts / 30.0) * 30;
     endTime_ = std::ceil(request.end_ts / 30.0) * 30;
+  } else if (request.__isset.min_ago) {
+    startTime_ = std::time(nullptr) - (60 * request.min_ago);
+    endTime_ = std::time(nullptr);
   } else {
     // default to 1 day here
     startTime_ = std::time(nullptr) - (24 * 60 * 60);

--- a/beringei/tools/query_service/QueryHandler.cpp
+++ b/beringei/tools/query_service/QueryHandler.cpp
@@ -104,7 +104,12 @@ void QueryHandler::columnNames() {
     std::unordered_set<std::string> displayNames;
     for (const auto& keyData : query_.data) {
       keyNames.insert(keyData.key);
-      linkNames.insert(keyData.linkName);
+      // add title append
+      if (keyData.__isset.linkTitleAppend) {
+        linkNames.insert(keyData.linkName + " " + keyData.linkTitleAppend);
+      } else {
+        linkNames.insert(keyData.linkName);
+      }
       nodeNames.insert(keyData.nodeName);
       displayNames.insert(keyData.displayName);
     }
@@ -112,7 +117,11 @@ void QueryHandler::columnNames() {
       std::string columnName = keyData.node;
       if (keyData.linkName.length() &&
           linkNames.size() == query_.key_ids.size()) {
-        columnName = keyData.linkName;
+        if (keyData.__isset.linkTitleAppend) {
+          columnName = keyData.linkName + " " + keyData.linkTitleAppend;
+        } else {
+          columnName = keyData.linkName;
+        }
       } else if (keyData.displayName.length() &&
                  displayNames.size() == query_.key_ids.size()) {
         columnName = keyData.displayName;

--- a/beringei/tools/query_service/QueryHandler.h
+++ b/beringei/tools/query_service/QueryHandler.h
@@ -43,13 +43,13 @@ class QueryHandler : public proxygen::RequestHandler {
   void onError(proxygen::ProxygenError err) noexcept override;
 
  private:
-  void logRequest(QueryRequest request);
+  void logRequest(query::QueryRequest request);
 
   int getShardId(const std::string& key, const int numShards);
 
-  void validateQuery(const Query& request);
+  void validateQuery(const query::Query& request);
   GetDataRequest createBeringeiRequest(
-      const Query& request,
+      const query::Query& request,
       const int numShards);
 
   /**
@@ -72,7 +72,7 @@ class QueryHandler : public proxygen::RequestHandler {
   std::shared_ptr<BeringeiClient> beringeiClient_;
   std::unique_ptr<folly::IOBuf> body_;
   // request data
-  Query query_;
+  query::Query query_;
   time_t startTime_;
   time_t endTime_;
   std::vector<std::string> columnNames_;

--- a/beringei/tools/query_service/QueryHandler.h
+++ b/beringei/tools/query_service/QueryHandler.h
@@ -61,9 +61,10 @@ class QueryHandler : public proxygen::RequestHandler {
    * data points, filling missing data with 0s.
    * timeBuckets_ size should be the same as each key's time series
    */
-  folly::fbstring transform();
-  folly::fbstring handleQuery();
-  folly::fbstring eventHandler(int dataPointIncrementMs);
+  folly::dynamic transform();
+  folly::dynamic handleQuery();
+  folly::dynamic eventHandler(int dataPointIncrementMs,
+                              const std::string& metricName);
   folly::dynamic makeEvent(int64_t startIndex, int64_t endIndex);
   std::string getTimeStr(time_t timeSec);
 

--- a/beringei/tools/query_service/QueryHandler.h
+++ b/beringei/tools/query_service/QueryHandler.h
@@ -27,8 +27,7 @@ typedef std::vector<std::pair<Key, std::vector<TimeValuePair>>> TimeSeries;
 class QueryHandler : public proxygen::RequestHandler {
  public:
   explicit QueryHandler(
-      std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter,
-      std::shared_ptr<BeringeiClient> beringeiClient);
+      std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter);
   void onRequest(
       std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override;
 
@@ -54,13 +53,13 @@ class QueryHandler : public proxygen::RequestHandler {
 
   /**
    * Determine column names to use based on KeyData
-   */
+   */ 
   void columnNames();
   /**
    * Transform the data from TimeValuePairs into lists of
    * data points, filling missing data with 0s.
    * timeBuckets_ size should be the same as each key's time series
-   */
+   */ 
   folly::fbstring transform();
   folly::fbstring handleQuery();
   folly::fbstring eventHandler(int dataPointIncrementMs);
@@ -68,7 +67,6 @@ class QueryHandler : public proxygen::RequestHandler {
   std::string getTimeStr(time_t timeSec);
 
   std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter_;
-  std::shared_ptr<BeringeiClient> beringeiClient_;
   std::unique_ptr<folly::IOBuf> body_;
   // request data
   Query query_;

--- a/beringei/tools/query_service/QueryHandler.h
+++ b/beringei/tools/query_service/QueryHandler.h
@@ -27,7 +27,8 @@ typedef std::vector<std::pair<Key, std::vector<TimeValuePair>>> TimeSeries;
 class QueryHandler : public proxygen::RequestHandler {
  public:
   explicit QueryHandler(
-      std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter);
+      std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter,
+      std::shared_ptr<BeringeiClient> beringeiClient);
   void onRequest(
       std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override;
 
@@ -53,13 +54,13 @@ class QueryHandler : public proxygen::RequestHandler {
 
   /**
    * Determine column names to use based on KeyData
-   */ 
+   */
   void columnNames();
   /**
    * Transform the data from TimeValuePairs into lists of
    * data points, filling missing data with 0s.
    * timeBuckets_ size should be the same as each key's time series
-   */ 
+   */
   folly::fbstring transform();
   folly::fbstring handleQuery();
   folly::fbstring eventHandler(int dataPointIncrementMs);
@@ -67,6 +68,7 @@ class QueryHandler : public proxygen::RequestHandler {
   std::string getTimeStr(time_t timeSec);
 
   std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter_;
+  std::shared_ptr<BeringeiClient> beringeiClient_;
   std::unique_ptr<folly::IOBuf> body_;
   // request data
   Query query_;

--- a/beringei/tools/query_service/QueryHandler.h
+++ b/beringei/tools/query_service/QueryHandler.h
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include <folly/futures/Future.h>
+#include <folly/Memory.h>
+#include <folly/dynamic.h>
+#include <proxygen/httpserver/RequestHandler.h>
+
+#include "beringei/client/BeringeiClient.h"
+#include "beringei/client/BeringeiConfigurationAdapterIf.h"
+#include "beringei/if/gen-cpp2/beringei_grafana_types_custom_protocol.h"
+
+
+namespace facebook {
+namespace gorilla {
+
+typedef std::vector<std::pair<Key, std::vector<TimeValuePair>>> TimeSeries;
+
+class QueryHandler : public proxygen::RequestHandler {
+ public:
+  explicit QueryHandler(
+      std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter);
+  void onRequest(
+      std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override;
+
+  void onBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
+
+  void onEOM() noexcept override;
+
+  void onUpgrade(proxygen::UpgradeProtocol proto) noexcept override;
+
+  void requestComplete() noexcept override;
+
+  void onError(proxygen::ProxygenError err) noexcept override;
+
+ private:
+  void logRequest(QueryRequest request);
+
+  int getShardId(const std::string& key, const int numShards);
+
+  GetDataRequest createBeringeiRequest(
+      const Query& request,
+      const int numShards);
+
+/*  folly::dynamic columnNames(
+    const std::string& aggType,
+    const std::vector<KeyData>& keyDataList);
+
+  folly::dynamic transformData(
+    const std::string& aggType,
+    const std::vector<KeyData>& keyDataList,
+    const TimeSeries& timeSeries);
+
+  folly::fbstring handleKeyQuery(
+    const std::string& aggType,
+    const std::vector<KeyData>& keyDataList,
+    const TimeSeries& timeSeries);
+
+  void postprocessData(
+    folly::dynamic& datapoints,
+    const std::string& aggType,
+    const std::vector<KeyData>& keyDataList);*/
+
+  /**
+   * Determine column names to use based on KeyData
+   */ 
+  void columnNames();
+  /**
+   * Transform the data from TimeValuePairs into lists of
+   * data points, filling missing data with 0s.
+   * timeBuckets_ size should be the same as each key's time series
+   */ 
+  folly::fbstring transform();
+  folly::fbstring handleQuery();
+  folly::fbstring eventHandler(int dataPointIncrementMs);
+
+  std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter_;
+  std::unique_ptr<folly::IOBuf> body_;
+  // request data
+  Query query_;
+  time_t startTime_;
+  time_t endTime_;
+  std::vector<std::string> columnNames_;
+  TimeSeries beringeiTimeSeries_;
+  // regular key time series
+  std::vector<std::vector<double>> timeSeries_;
+  // aggregated series (avg, min, max, sum, count)
+  // all displayed by default
+  std::unordered_map<std::string, std::vector<double>> aggSeries_;
+};
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/QueryHandler.h
+++ b/beringei/tools/query_service/QueryHandler.h
@@ -46,6 +46,7 @@ class QueryHandler : public proxygen::RequestHandler {
 
   int getShardId(const std::string& key, const int numShards);
 
+  void validateQuery(const Query& request);
   GetDataRequest createBeringeiRequest(
       const Query& request,
       const int numShards);

--- a/beringei/tools/query_service/QueryHandler.h
+++ b/beringei/tools/query_service/QueryHandler.h
@@ -16,7 +16,7 @@
 
 #include "beringei/client/BeringeiClient.h"
 #include "beringei/client/BeringeiConfigurationAdapterIf.h"
-#include "beringei/if/gen-cpp2/beringei_grafana_types_custom_protocol.h"
+#include "beringei/if/gen-cpp2/beringei_query_types_custom_protocol.h"
 
 
 namespace facebook {
@@ -50,25 +50,6 @@ class QueryHandler : public proxygen::RequestHandler {
       const Query& request,
       const int numShards);
 
-/*  folly::dynamic columnNames(
-    const std::string& aggType,
-    const std::vector<KeyData>& keyDataList);
-
-  folly::dynamic transformData(
-    const std::string& aggType,
-    const std::vector<KeyData>& keyDataList,
-    const TimeSeries& timeSeries);
-
-  folly::fbstring handleKeyQuery(
-    const std::string& aggType,
-    const std::vector<KeyData>& keyDataList,
-    const TimeSeries& timeSeries);
-
-  void postprocessData(
-    folly::dynamic& datapoints,
-    const std::string& aggType,
-    const std::vector<KeyData>& keyDataList);*/
-
   /**
    * Determine column names to use based on KeyData
    */ 
@@ -81,6 +62,8 @@ class QueryHandler : public proxygen::RequestHandler {
   folly::fbstring transform();
   folly::fbstring handleQuery();
   folly::fbstring eventHandler(int dataPointIncrementMs);
+  folly::dynamic makeEvent(int64_t startIndex, int64_t endIndex);
+  std::string getTimeStr(time_t timeSec);
 
   std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter_;
   std::unique_ptr<folly::IOBuf> body_;

--- a/beringei/tools/query_service/QueryServiceFactory.cpp
+++ b/beringei/tools/query_service/QueryServiceFactory.cpp
@@ -9,9 +9,12 @@
 
 #include "QueryServiceFactory.h"
 
+#include "AlertsWriteHandler.h"
+#include "EventsWriteHandler.h"
+#include "LogsWriteHandler.h"
 #include "NotFoundHandler.h"
 #include "QueryHandler.h"
-#include "WriteHandler.h"
+#include "StatsWriteHandler.h"
 
 #include "beringei/plugins/BeringeiConfigurationAdapter.h"
 
@@ -44,10 +47,16 @@ proxygen::RequestHandler* QueryServiceFactory::onRequest(
   LOG(INFO) << "Received a request for path " << path;
 
   if (path == "/stats_writer") {
-    return new WriteHandler(
+    return new StatsWriteHandler(
         configurationAdapter_, mySqlClient_, beringeiWriteClient_);
   } else if (path == "/query") {
     return new QueryHandler(configurationAdapter_, beringeiReadClient_);
+  } else if (path == "/events_writer") {
+    return new EventsWriteHandler(mySqlClient_);
+  } else if (path == "/alerts_writer") {
+    return new AlertsWriteHandler(mySqlClient_);
+  } else if (path == "/logs_writer") {
+    return new LogsWriteHandler();
   }
 
   // return not found for all other uris

--- a/beringei/tools/query_service/QueryServiceFactory.cpp
+++ b/beringei/tools/query_service/QueryServiceFactory.cpp
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "QueryServiceFactory.h"
+
+#include "NotFoundHandler.h"
+#include "QueryHandler.h"
+
+#include "beringei/plugins/BeringeiConfigurationAdapter.h"
+
+using folly::EventBase;
+using folly::EventBaseManager;
+using folly::SocketAddress;
+
+namespace facebook {
+namespace gorilla {
+
+QueryServiceFactory::QueryServiceFactory() : RequestHandlerFactory() {
+  configurationAdapter_ = std::make_shared<BeringeiConfigurationAdapter>();
+}
+
+void QueryServiceFactory::onServerStart(
+    folly::EventBase* evb) noexcept {
+}
+
+void QueryServiceFactory::onServerStop() noexcept {}
+
+proxygen::RequestHandler* QueryServiceFactory::onRequest(
+    proxygen::RequestHandler* /* unused */,
+    proxygen::HTTPMessage* httpMessage) noexcept {
+  auto path = httpMessage->getPath();
+  LOG(INFO) << "Received a request for path " << path;
+
+  if (path == "/query") {
+    return new QueryHandler(configurationAdapter_);
+  }
+
+  // return not found for all other uris
+  return new NotFoundHandler();
+}
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/QueryServiceFactory.cpp
+++ b/beringei/tools/query_service/QueryServiceFactory.cpp
@@ -11,6 +11,7 @@
 
 #include "NotFoundHandler.h"
 #include "QueryHandler.h"
+#include "WriteHandler.h"
 
 #include "beringei/plugins/BeringeiConfigurationAdapter.h"
 
@@ -18,16 +19,21 @@ using folly::EventBase;
 using folly::EventBaseManager;
 using folly::SocketAddress;
 
+DEFINE_int32(writer_queue_size, 100000, "Beringei writer queue size");
+
 namespace facebook {
 namespace gorilla {
 
 QueryServiceFactory::QueryServiceFactory() : RequestHandlerFactory() {
   configurationAdapter_ = std::make_shared<BeringeiConfigurationAdapter>();
+  mySqlClient_ = std::make_shared<MySqlClient>();
+  beringeiReadClient_ = std::make_shared<BeringeiClient>(
+      configurationAdapter_, 1, BeringeiClient::kNoWriterThreads);
+  beringeiWriteClient_ = std::make_shared<BeringeiClient>(
+      configurationAdapter_, FLAGS_writer_queue_size, 5);
 }
 
-void QueryServiceFactory::onServerStart(
-    folly::EventBase* evb) noexcept {
-}
+void QueryServiceFactory::onServerStart(folly::EventBase* evb) noexcept {}
 
 void QueryServiceFactory::onServerStop() noexcept {}
 
@@ -37,8 +43,11 @@ proxygen::RequestHandler* QueryServiceFactory::onRequest(
   auto path = httpMessage->getPath();
   LOG(INFO) << "Received a request for path " << path;
 
-  if (path == "/query") {
-    return new QueryHandler(configurationAdapter_);
+  if (path == "/stats_writer") {
+    return new WriteHandler(
+        configurationAdapter_, mySqlClient_, beringeiWriteClient_);
+  } else if (path == "/query") {
+    return new QueryHandler(configurationAdapter_, beringeiReadClient_);
   }
 
   // return not found for all other uris

--- a/beringei/tools/query_service/QueryServiceFactory.h
+++ b/beringei/tools/query_service/QueryServiceFactory.h
@@ -8,6 +8,8 @@
  */
 #pragma once
 
+#include "MySqlClient.h"
+#include "beringei/client/BeringeiClient.h"
 #include "beringei/client/BeringeiConfigurationAdapterIf.h"
 
 #include <folly/Memory.h>
@@ -36,6 +38,9 @@ class QueryServiceFactory : public proxygen::RequestHandlerFactory {
  private:
   std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter_;
   folly::EventBase* eb_;
+  std::shared_ptr<MySqlClient> mySqlClient_;
+  std::shared_ptr<BeringeiClient> beringeiReadClient_;
+  std::shared_ptr<BeringeiClient> beringeiWriteClient_;
 };
 }
 } // facebook::gorilla

--- a/beringei/tools/query_service/QueryServiceFactory.h
+++ b/beringei/tools/query_service/QueryServiceFactory.h
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#pragma once
+
+#include "beringei/client/BeringeiConfigurationAdapterIf.h"
+
+#include <folly/Memory.h>
+#include <folly/Portability.h>
+#include <folly/io/async/EventBaseManager.h>
+#include <gflags/gflags.h>
+#include <proxygen/httpserver/HTTPServer.h>
+#include <proxygen/httpserver/RequestHandlerFactory.h>
+
+namespace facebook {
+namespace gorilla {
+
+// Request handler factory that figures out the right handler based on the uri
+class QueryServiceFactory : public proxygen::RequestHandlerFactory {
+ public:
+  QueryServiceFactory();
+
+  void onServerStart(folly::EventBase* evb) noexcept override;
+
+  void onServerStop() noexcept override;
+
+  proxygen::RequestHandler* onRequest(
+      proxygen::RequestHandler*,
+      proxygen::HTTPMessage*) noexcept override;
+
+ private:
+  std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter_;
+  folly::EventBase* eb_;
+};
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/QueryServiceFactory.h
+++ b/beringei/tools/query_service/QueryServiceFactory.h
@@ -8,8 +8,6 @@
  */
 #pragma once
 
-#include "MySqlClient.h"
-#include "beringei/client/BeringeiClient.h"
 #include "beringei/client/BeringeiConfigurationAdapterIf.h"
 
 #include <folly/Memory.h>
@@ -38,9 +36,6 @@ class QueryServiceFactory : public proxygen::RequestHandlerFactory {
  private:
   std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter_;
   folly::EventBase* eb_;
-  std::shared_ptr<MySqlClient> mySqlClient_;
-  std::shared_ptr<BeringeiClient> beringeiReadClient_;
-  std::shared_ptr<BeringeiClient> beringeiWriteClient_;
 };
 }
 } // facebook::gorilla

--- a/beringei/tools/query_service/StatsTypeAheadHandler.cpp
+++ b/beringei/tools/query_service/StatsTypeAheadHandler.cpp
@@ -1,0 +1,286 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "mysql_connection.h"
+#include "mysql_driver.h"
+#include "StatsTypeAheadHandler.h"
+
+#include <algorithm>
+#include <utility>
+#include <map>
+
+#include <cppconn/driver.h>
+#include <cppconn/exception.h>
+#include <cppconn/prepared_statement.h>
+#include <cppconn/resultset.h>
+#include <cppconn/statement.h>
+#include <folly/DynamicConverter.h>
+#include <folly/Conv.h>
+#include <folly/io/IOBuf.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include <thrift/lib/cpp/util/ThriftSerializer.h>
+#include <thrift/lib/cpp2/protocol/Serializer.h>
+
+using apache::thrift::SimpleJSONSerializer;
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::system_clock;
+using namespace proxygen;
+
+namespace facebook {
+namespace gorilla {
+
+StatsTypeAheadHandler::StatsTypeAheadHandler(
+    std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter,
+    std::shared_ptr<MySqlClient> mySqlClient,
+    std::shared_ptr<BeringeiClient> beringeiClient)
+    : RequestHandler(),
+      configurationAdapter_(configurationAdapter),
+      mySqlClient_(mySqlClient),
+      beringeiClient_(beringeiClient) {
+  metricKeyNames_ = { "snr", "rssi", "mcs", "per", "fw_uptime", "tx_power",
+                      "rx_bytes", "tx_bytes", "rx_pps", "tx_pps", "rx_errors",
+                      "tx_errors", "rx_dropped", "tx_dropped", "rx_frame",
+                      "rx_overruns", "tx_overruns", "tx_collisions", "speed" };
+}
+
+void StatsTypeAheadHandler::onRequest(
+    std::unique_ptr<HTTPMessage> /* unused */) noexcept {
+  // nothing to do
+}
+
+void StatsTypeAheadHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept {
+  if (body_) {
+    body_->prependChain(move(body));
+  } else {
+    body_ = move(body);
+  }
+}
+
+void StatsTypeAheadHandler::fetchMetricNames(query::Topology& request) {
+  for (auto& n : request.nodes) {
+    std::transform(
+        n.mac_addr.begin(), n.mac_addr.end(), n.mac_addr.begin(), ::tolower);
+    macNodes_.push_back(n.mac_addr);
+  }
+
+  auto nodes = mySqlClient_->getNodes(macNodes_);
+  folly::dynamic nodeData;
+  for (auto& node : nodes) {
+    std::transform(node.mac.begin(), node.mac.end(), node.mac.begin(), ::tolower);
+    std::transform(node.key.begin(), node.key.end(), node.key.begin(), ::tolower);
+    folly::StringPiece key = folly::StringPiece(node.key);
+    if (key.endsWith("count.0") ||
+        key.endsWith("count.600") ||
+        key.endsWith("count.3600")) {
+      continue;
+    }
+    nodeData = folly::dynamic::object("dbKeyId", node.id);
+
+    nodeMetrics_ = folly::dynamic::object(node.mac, 
+			folly::dynamic::object(node.key, nodeData));
+    siteMetrics_ = folly::dynamic::object(node.site, folly::dynamic::object(node.node,
+			folly::dynamic::object(node.key, nodeData)));
+  }
+
+  for(auto& link : request.links) {
+    auto aNode = mySqlClient_->getNode(link.a_node_name);
+    auto zNode = mySqlClient_->getNode(link.z_node_name);
+    for (auto& metricName : metricKeyNames_) {
+      folly::dynamic linkMetrics = getLinkMetrics(metricName, aNode, zNode);
+      for (auto& key : linkMetrics["keys"]) {
+      	auto node = SimpleJSONSerializer::deserialize<query::MySqlNodeData>(key["node"].asString());
+        auto mac = node.mac;
+        auto keyName = key["keyName"].asString();
+
+        if (nodeMetrics_.find(mac) == nodeMetrics_.items().end() ||
+            nodeMetrics_[mac].find(keyName) == nodeMetrics_[mac].items().end()) {
+          continue;
+        }
+        
+        nodeData = nodeMetrics_[mac][keyName];
+        nodeData["displayName"] = linkMetrics["title"].asString();
+        nodeData["linkName"] = link.name;
+        nodeData["linkTitleAppend"] = key["titleAppend"].asString();
+        nodeData["title"] = linkMetrics["title"].asString() + key["titleAppend"].asString();
+        nodeData["description"] = linkMetrics["description"].asString();
+        nodeData["scale"] = linkMetrics["scale"].asString();
+      	siteMetrics_[node.site][node.node][node.key] = nodeData;
+      } 
+    } 
+  }
+}
+
+folly::dynamic StatsTypeAheadHandler::createLinkMetric(query::MySqlNodeData& aNode, query::MySqlNodeData& zNode,
+                                                       std::string title, std::string description,
+                                                       std::string keyName, std::string keyPrefix) {
+  return folly::dynamic::object
+    ("title", title)
+    ("description", description)
+    ("scale", NULL)
+    ("keys", folly::dynamic::array(
+      folly::dynamic::object
+        ("node", SimpleJSONSerializer::serialize<std::string>(aNode))
+        ("keyName", keyPrefix + "." + zNode.mac + "." + keyName)
+        ("titleAppend", " (A)"),
+      folly::dynamic::object
+        ("node", SimpleJSONSerializer::serialize<std::string>(zNode))
+        ("keyName", keyPrefix + "." + aNode.mac + "." + keyName)
+        ("titleAppend", " (Z)")));
+}
+
+folly::dynamic StatsTypeAheadHandler::getLinkMetrics(std::string& metricName, query::MySqlNodeData& aNode, query::MySqlNodeData& zNode) {
+  if (metricName == "rssi")
+    return createLinkMetric(aNode, zNode,
+                            "RSSI", "Received Signal Strength Indicator",
+                            "phystatus.srssi");
+  else if (metricName == "snr" || 
+           metricName == "alive_snr" || 
+           metricName == "alive_perc")
+    return createLinkMetric(aNode, zNode,
+                            "SnR", "Signal to Noise Ratio",
+                            "phystatus.ssnrEst");
+  else if (metricName == "mcs")
+    return createLinkMetric(aNode, zNode,
+                            "MCS", "MCS Index",
+                            "staPkt.mcs");
+  else if (metricName == "per")
+    return createLinkMetric(aNode, zNode,
+                            "PER", "Packet Error Rate",
+                            "staPkt.perE6");
+  else if (metricName == "fw_uptime")
+    return createLinkMetric(aNode, zNode,
+                            "FW Uptime", "Mgmt Tx Keepalive Count",
+                            "mgmtTx.keepAlive");
+  else if (metricName == "rx_ok")
+    return createLinkMetric(aNode, zNode,
+                            "RX Packets", "Received packets",
+                            "staPkt.rxOk");
+  else if (metricName == "tx_ok")
+    return createLinkMetric(aNode, zNode,
+                            "TX Packets", "Transferred packets",
+                            "staPkt.txOk");
+  else if (metricName == "tx_bytes")
+    return createLinkMetric(aNode, zNode,
+                            "TX bps", "Transferred bits/second",
+                            "tx_bytes", "link");
+  else if (metricName == "rx_bytes")
+    return createLinkMetric(aNode, zNode,
+                            "RX bps", "Received bits/second",
+                            "rx_bytes", "link");
+  else if (metricName == "tx_errors")
+    return createLinkMetric(aNode, zNode,
+                            "TX errors", "Transmit errors/second",
+                            "tx_errors", "link");
+  else if (metricName == "rx_errors")
+    return createLinkMetric(aNode, zNode,
+                            "RX errors", "Receive errors/second",
+                            "rx_errors", "link");
+  else if (metricName == "tx_dropped")
+    return createLinkMetric(aNode, zNode,
+                            "TX dropped", "Transmit packets/second",
+                            "tx_dropped", "link");
+  else if (metricName == "rx_dropped")
+    return createLinkMetric(aNode, zNode,
+                            "RX dropped", "Receive packets/second",
+                            "rx_dropped", "link");
+  else if (metricName == "tx_pps")
+    return createLinkMetric(aNode, zNode,
+                            "TX pps", "Transmit packets/second",
+                            "tc_packets", "link");
+  else if (metricName == "rx_pps")
+    return createLinkMetric(aNode, zNode,
+                            "RX pps", "Receive packets/second",
+                            "rc_packets", "link");
+  else if (metricName == "tx_power")
+    return createLinkMetric(aNode, zNode,
+                            "TX Power", "Transmit Power",
+                            "tpcStats.txPowerIndex");
+  else if (metricName == "rx_frame")
+    return createLinkMetric(aNode, zNode,
+                            "RX Frame", "RX Frame",
+                            "rx_frame", "link");
+  else if (metricName == "rx_overruns")
+    return createLinkMetric(aNode, zNode,
+                            "RX Overruns", "RX Overruns",
+                            "rx_overruns", "link");
+  else if (metricName == "tx_overruns")
+    return createLinkMetric(aNode, zNode,
+                            "TX Overruns", "TX Overruns",
+                            "tx_overruns", "link");
+  else if (metricName == "tx_collisions")
+    return createLinkMetric(aNode, zNode,
+                            "TX Collisions", "TX Collisions",
+                            "tx_collisions", "link");
+  else if (metricName == "speed")
+    return createLinkMetric(aNode, zNode,
+                            "Speed", "Speed (mbps)",
+                            "speed", "link");
+  else if (metricName == "link_status")
+    return folly::dynamic::object
+      ("title", "Link status")
+      ("description", "Link status reported by controller")
+      ("scale", NULL)
+      ("keys", folly::dynamic::array(
+        folly::dynamic::object
+          ("node", SimpleJSONSerializer::serialize<std::string>(aNode))
+          ("keyName", "e2e_controller.link_status.WIRELESS." + aNode.mac + "." + zNode.mac)
+          ("titleAppend", " (A)")));
+}
+
+void StatsTypeAheadHandler::onEOM() noexcept {
+  auto body = body_->moveToFbString();
+  query::Topology request;
+  try {
+    request = SimpleJSONSerializer::deserialize<query::Topology>(body);
+  } catch (const std::exception& ex) {
+    LOG(INFO) << "Error deserializing stats type ahead request";
+    LOG(INFO) << body;
+    ResponseBuilder(downstream_)
+        .status(500, "OK")
+        .header("Content-Type", "application/json")
+        .body("Failed de-serializing stats type ahead request")
+        .sendWithEOM();
+    return;
+  }
+  LOG(INFO) << "Stats type ahead request from \"" << request.name;
+
+  try {
+    fetchMetricNames(request);
+  } catch (const std::exception& ex) {
+    LOG(ERROR) << "Unable to handle stats_type_ahead request: " << ex.what();
+    ResponseBuilder(downstream_)
+        .status(500, "OK")
+        .header("Content-Type", "application/json")
+        .body("Failed handling stats_type_ahead request")
+        .sendWithEOM();
+    return;
+  }
+  ResponseBuilder(downstream_)
+      .status(200, "OK")
+      .header("Content-Type", "application/json")
+      .body(folly::toJson(siteMetrics_))
+      .sendWithEOM();
+}
+
+void StatsTypeAheadHandler::onUpgrade(UpgradeProtocol /* unused */) noexcept {}
+
+void StatsTypeAheadHandler::requestComplete() noexcept {
+  delete this;
+}
+
+void StatsTypeAheadHandler::onError(ProxygenError /* unused */) noexcept {
+  LOG(ERROR) << "Proxygen reported error";
+  // In QueryServiceFactory, we created this handler using new.
+  // Proxygen does not delete the handler.
+  delete this;
+}
+
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/StatsTypeAheadHandler.h
+++ b/beringei/tools/query_service/StatsTypeAheadHandler.h
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include "boost/variant.hpp"
+#include "MySqlClient.h"
+
+#include <folly/Memory.h>
+#include <folly/dynamic.h>
+#include <folly/futures/Future.h>
+#include <proxygen/httpserver/RequestHandler.h>
+
+#include "beringei/client/BeringeiClient.h"
+#include "beringei/client/BeringeiConfigurationAdapterIf.h"
+#include "beringei/if/gen-cpp2/beringei_query_types_custom_protocol.h"
+
+namespace facebook {
+namespace gorilla {
+
+class StatsTypeAheadHandler : public proxygen::RequestHandler {
+ public:
+  explicit StatsTypeAheadHandler(
+      std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter,
+      std::shared_ptr<MySqlClient> mySqlClient,
+      std::shared_ptr<BeringeiClient> beringeiClient);
+
+  void onRequest(
+      std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override;
+
+  void onBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
+
+  void fetchMetricNames(query::Topology& request);
+
+  folly::dynamic createLinkMetric(query::MySqlNodeData& aNode, query::MySqlNodeData& zNode,
+			     	std::string title, std::string description,
+				std::string keyName, std::string keyPrefix = "tgf");
+
+  folly::dynamic getLinkMetrics(std::string& metricName, query::MySqlNodeData& aNode, query::MySqlNodeData& zNode);
+
+  void onEOM() noexcept override;
+
+  void onUpgrade(proxygen::UpgradeProtocol proto) noexcept override;
+
+  void requestComplete() noexcept override;
+
+  void onError(proxygen::ProxygenError err) noexcept override;
+
+ private:
+  std::vector<std::string> metricKeyNames_;
+  std::vector<std::string> macNodes_{};
+  folly::dynamic nodeMetrics_;
+  folly::dynamic siteMetrics_;
+  std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter_;
+  std::shared_ptr<MySqlClient> mySqlClient_;
+  std::shared_ptr<BeringeiClient> beringeiClient_;
+  std::unique_ptr<folly::IOBuf> body_;
+};
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/StatsWriteHandler.cpp
+++ b/beringei/tools/query_service/StatsWriteHandler.cpp
@@ -8,25 +8,22 @@
  */
 
 #include "StatsWriteHandler.h"
-
-#include <utility>
-
-#include <folly/DynamicConverter.h>
-#include <folly/io/IOBuf.h>
-#include <proxygen/httpserver/ResponseBuilder.h>
-#include <thrift/lib/cpp/util/ThriftSerializer.h>
-#include <thrift/lib/cpp2/protocol/Serializer.h>
-
 #include "mysql_connection.h"
 #include "mysql_driver.h"
+
+#include <algorithm>
+#include <utility>
 
 #include <cppconn/driver.h>
 #include <cppconn/exception.h>
 #include <cppconn/prepared_statement.h>
 #include <cppconn/resultset.h>
 #include <cppconn/statement.h>
-
-#include <algorithm>
+#include <folly/DynamicConverter.h>
+#include <folly/io/IOBuf.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include <thrift/lib/cpp/util/ThriftSerializer.h>
+#include <thrift/lib/cpp2/protocol/Serializer.h>
 
 using apache::thrift::SimpleJSONSerializer;
 using std::chrono::duration_cast;
@@ -189,7 +186,6 @@ void StatsWriteHandler::onEOM() noexcept {
   LOG(INFO) << "Stats writer request from \"" << request.topology.name
             << "\" for " << request.agents.size() << " nodes";
 
-  folly::fbstring jsonResp;
   try {
     writeData(request);
   } catch (const std::exception& ex) {
@@ -204,7 +200,7 @@ void StatsWriteHandler::onEOM() noexcept {
   ResponseBuilder(downstream_)
       .status(200, "OK")
       .header("Content-Type", "application/json")
-      .body(jsonResp)
+      .body("Success")
       .sendWithEOM();
 }
 

--- a/beringei/tools/query_service/StatsWriteHandler.cpp
+++ b/beringei/tools/query_service/StatsWriteHandler.cpp
@@ -97,8 +97,8 @@ int64_t timeCalc(int64_t timeIn) {
       FLAGS_agg_bucket_seconds;
 }
 
-void StatsWriteHandler::writeData(StatsWriteRequest request) {
-  std::unordered_map<std::string, MySqlNodeData> unknownNodes;
+void StatsWriteHandler::writeData(query::StatsWriteRequest request) {
+  std::unordered_map<std::string, query::MySqlNodeData> unknownNodes;
   std::unordered_map<int64_t, std::unordered_set<std::string>> missingNodeKey;
   std::vector<DataPoint> bRows;
 
@@ -109,7 +109,7 @@ void StatsWriteHandler::writeData(StatsWriteRequest request) {
   for (const auto& agent : request.agents) {
     auto nodeId = mySqlClient_->getNodeId(agent.mac);
     if (!nodeId) {
-      MySqlNodeData newNode;
+      query::MySqlNodeData newNode;
       newNode.mac = agent.mac;
       newNode.node = agent.name;
       newNode.site = agent.site;
@@ -170,9 +170,9 @@ void StatsWriteHandler::writeData(StatsWriteRequest request) {
 
 void StatsWriteHandler::onEOM() noexcept {
   auto body = body_->moveToFbString();
-  StatsWriteRequest request;
+  query::StatsWriteRequest request;
   try {
-    request = SimpleJSONSerializer::deserialize<StatsWriteRequest>(body);
+    request = SimpleJSONSerializer::deserialize<query::StatsWriteRequest>(body);
   } catch (const std::exception&) {
     LOG(INFO) << "Error deserializing stats_writer request";
     ResponseBuilder(downstream_)
@@ -217,6 +217,6 @@ void StatsWriteHandler::onError(ProxygenError /* unused */) noexcept {
   delete this;
 }
 
-void StatsWriteHandler::logRequest(StatsWriteRequest request) {}
+void StatsWriteHandler::logRequest(query::StatsWriteRequest request) {}
 }
 } // facebook::gorilla

--- a/beringei/tools/query_service/StatsWriteHandler.h
+++ b/beringei/tools/query_service/StatsWriteHandler.h
@@ -44,9 +44,9 @@ class StatsWriteHandler : public proxygen::RequestHandler {
   void onError(proxygen::ProxygenError err) noexcept override;
 
  private:
-  void logRequest(StatsWriteRequest request);
+  void logRequest(query::StatsWriteRequest request);
 
-  void writeData(StatsWriteRequest request);
+  void writeData(query::StatsWriteRequest request);
 
   std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter_;
   std::shared_ptr<MySqlClient> mySqlClient_;

--- a/beringei/tools/query_service/StatsWriteHandler.h
+++ b/beringei/tools/query_service/StatsWriteHandler.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#pragma once
+
+#include "MySqlClient.h"
+
+#include <folly/Memory.h>
+#include <folly/dynamic.h>
+#include <folly/futures/Future.h>
+#include <proxygen/httpserver/RequestHandler.h>
+
+#include "beringei/client/BeringeiClient.h"
+#include "beringei/client/BeringeiConfigurationAdapterIf.h"
+#include "beringei/if/gen-cpp2/beringei_query_types_custom_protocol.h"
+
+namespace facebook {
+namespace gorilla {
+
+class StatsWriteHandler : public proxygen::RequestHandler {
+ public:
+  explicit StatsWriteHandler(
+      std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter,
+      std::shared_ptr<MySqlClient> mySqlClient,
+      std::shared_ptr<BeringeiClient> beringeiClient);
+
+  void onRequest(
+      std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override;
+
+  void onBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
+
+  void onEOM() noexcept override;
+
+  void onUpgrade(proxygen::UpgradeProtocol proto) noexcept override;
+
+  void requestComplete() noexcept override;
+
+  void onError(proxygen::ProxygenError err) noexcept override;
+
+ private:
+  void logRequest(StatsWriteRequest request);
+
+  void writeData(StatsWriteRequest request);
+
+  std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter_;
+  std::shared_ptr<MySqlClient> mySqlClient_;
+  std::shared_ptr<BeringeiClient> beringeiClient_;
+  std::unique_ptr<folly::IOBuf> body_;
+};
+}
+} // facebook::gorilla

--- a/beringei/tools/query_service/WriteHandler.cpp
+++ b/beringei/tools/query_service/WriteHandler.cpp
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "WriteHandler.h"
+
+#include <utility>
+
+#include <folly/DynamicConverter.h>
+#include <folly/io/IOBuf.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+#include <thrift/lib/cpp/util/ThriftSerializer.h>
+#include <thrift/lib/cpp2/protocol/Serializer.h>
+
+#include "mysql_connection.h"
+#include "mysql_driver.h"
+
+#include <cppconn/driver.h>
+#include <cppconn/exception.h>
+#include <cppconn/prepared_statement.h>
+#include <cppconn/resultset.h>
+#include <cppconn/statement.h>
+
+#include <algorithm>
+
+using apache::thrift::SimpleJSONSerializer;
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+using std::chrono::system_clock;
+using namespace proxygen;
+
+DEFINE_int32(agg_bucket_seconds, 30, "time aggregation bucket size");
+
+namespace facebook {
+namespace gorilla {
+
+WriteHandler::WriteHandler(
+    std::shared_ptr<BeringeiConfigurationAdapterIf> configurationAdapter,
+    std::shared_ptr<MySqlClient> mySqlClient,
+    std::shared_ptr<BeringeiClient> beringeiClient)
+    : RequestHandler(),
+      configurationAdapter_(configurationAdapter),
+      mySqlClient_(mySqlClient),
+      beringeiClient_(beringeiClient) {}
+
+void WriteHandler::onRequest(
+    std::unique_ptr<HTTPMessage> /* unused */) noexcept {
+  // nothing to do
+}
+
+void WriteHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept {
+  if (body_) {
+    body_->prependChain(move(body));
+  } else {
+    body_ = move(body);
+  }
+}
+
+int64_t timeCalc(int64_t timeIn) {
+  /*
+    int64_t timeInSeconds;
+    int64_t currentTime = std::time(nullptr);
+    int64_t min_s  = 1500000000;
+    int64_t min_ms = 1500000000000;
+    int64_t min_us = 1500000000000000;
+    int64_t min_ns = 1500000000000000000;
+    int64_t max_s  = 2000000000;
+    int64_t max_ms = 2000000000000;
+    int64_t max_us = 2000000000000000;
+    int64_t max_ns = 2000000000000000000;
+    if (timeIn < max_s && timeIn > min_s) {
+      timeInSeconds = timeIn;
+    } else if (timeIn < max_ms && timeIn > min_ms) {
+      timeInSeconds = timeIn / 1000;
+    } else if (timeIn < max_us && timeIn > min_us) {
+      timeInSeconds = timeIn / 1000000;
+    } else if (timeIn < max_ns && timeIn > min_ns) {
+      timeInSeconds = timeIn / 1000000000;
+    } else{
+      // just use current time
+      timeInSeconds = currentTime;
+    }
+
+    int64_t timeDiff = currentTime - timeInSeconds;
+    if (timeDiff > 30*60 || timeDiff < -30*60) {
+      LOG(INFO) << "Timestamp " << timeInSeconds
+                << " is out of sync with current time " << currentTime;
+      timeInSeconds = currentTime;
+    }
+    return folly::to<int64_t>(ceil (timeInSeconds / FLAGS_agg_bucket_seconds))
+      * FLAGS_agg_bucket_seconds;
+  */
+  return folly::to<int64_t>(
+             ceil(std::time(nullptr) / FLAGS_agg_bucket_seconds)) *
+      FLAGS_agg_bucket_seconds;
+}
+
+void WriteHandler::writeData(WriteRequest request) {
+  std::unordered_map<std::string, MySqlNodeData> unknownNodes;
+  std::unordered_map<int64_t, std::unordered_set<std::string>> missingNodeKey;
+  std::vector<DataPoint> bRows;
+
+  auto startTime = (int64_t)duration_cast<milliseconds>(
+                       system_clock::now().time_since_epoch())
+                       .count();
+
+  for (const auto& agent : request.agents) {
+    auto nodeId = mySqlClient_->getNodeId(agent.mac);
+    if (!nodeId) {
+      MySqlNodeData newNode;
+      newNode.mac = agent.mac;
+      newNode.node = agent.name;
+      newNode.site = agent.site;
+      newNode.network = request.topology.name;
+      unknownNodes[newNode.mac] = newNode;
+      LOG(INFO) << "Unknown mac: " << agent.mac;
+      continue;
+    }
+
+    for (const auto& stat : agent.stats) {
+      // check timestamp
+      int64_t tsParsed = timeCalc(stat.ts);
+      auto keyId = mySqlClient_->getKeyId(*nodeId, stat.key);
+      // verify node/key combo exists
+      if (keyId) {
+        // insert row for beringei
+        DataPoint bRow;
+        TimeValuePair timePair;
+        Key bKey;
+
+        bKey.key = std::to_string(*keyId);
+        bRow.key = bKey;
+        timePair.unixTime = tsParsed;
+        timePair.value = stat.value;
+        bRow.value = timePair;
+        bRows.push_back(bRow);
+      } else {
+        // LOG(INFO) << "Missing cache for " << *nodeId << "/" << stat.key;
+        missingNodeKey[*nodeId].insert(stat.key);
+      }
+    }
+  }
+  // write newly found macs and node/key combos
+  mySqlClient_->addNodes(unknownNodes);
+  mySqlClient_->updateNodeKeys(missingNodeKey);
+
+  // insert rows
+  if (bRows.size()) {
+    folly::EventBase eb;
+    eb.runInLoop([this, &bRows]() mutable {
+      auto pushedPoints = beringeiClient_->putDataPoints(bRows);
+      if (!pushedPoints) {
+        LOG(ERROR) << "Failed to perform the put!";
+      }
+    });
+    std::thread tEb([&eb]() { eb.loop(); });
+    tEb.join();
+
+    auto endTime = (int64_t)duration_cast<milliseconds>(
+                       system_clock::now().time_since_epoch())
+                       .count();
+    LOG(INFO) << "writeData completed. "
+              << "Total: " << (endTime - startTime) << "ms.";
+  } else {
+    LOG(INFO) << "writeData request failures";
+  }
+}
+
+void WriteHandler::onEOM() noexcept {
+  auto body = body_->moveToFbString();
+  WriteRequest request;
+  try {
+    request = SimpleJSONSerializer::deserialize<WriteRequest>(body);
+  } catch (const std::exception&) {
+    LOG(INFO) << "Error deserializing stats_writer request";
+    ResponseBuilder(downstream_)
+        .status(500, "OK")
+        .header("Content-Type", "application/json")
+        .body("Failed de-serializing stats_writer request")
+        .sendWithEOM();
+    return;
+  }
+  logRequest(request);
+  LOG(INFO) << "Stats write request from \"" << request.topology.name
+            << "\" for " << request.agents.size() << " nodes";
+
+  folly::fbstring jsonResp;
+  try {
+    writeData(request);
+  } catch (const std::exception& ex) {
+    LOG(ERROR) << "Unable to handle stats_write request: " << ex.what();
+    ResponseBuilder(downstream_)
+        .status(500, "OK")
+        .header("Content-Type", "application/json")
+        .body("Failed handling stats_write request")
+        .sendWithEOM();
+    return;
+  }
+  ResponseBuilder(downstream_)
+      .status(200, "OK")
+      .header("Content-Type", "application/json")
+      .body(jsonResp)
+      .sendWithEOM();
+}
+
+void WriteHandler::onUpgrade(UpgradeProtocol /* unused */) noexcept {}
+
+void WriteHandler::requestComplete() noexcept {
+  delete this;
+}
+
+void WriteHandler::onError(ProxygenError /* unused */) noexcept {
+  LOG(ERROR) << "Proxygen reported error";
+  // In QueryServiceFactory, we created this handler using new.
+  // Proxygen does not delete the handler.
+  delete this;
+}
+
+void WriteHandler::logRequest(WriteRequest request) {}
+}
+} // facebook::gorilla


### PR DESCRIPTION
Adapted from queryHelper.js

-accept a topology json struct which includes nodes, links, sites, etc.
-fetch all key ids for the given topology name from the db
-allow a formatter to take the key names in the DB and transform them into their short-names
-return a list of the key names